### PR TITLE
Update command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 monorepo-diff-buildkite-plugin*
 .envrc
 dist
+
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,3 @@
 monorepo-diff-buildkite-plugin*
 .envrc
 dist
-
-dist/

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Configuration supports 2 different step types.
     steps:
       - label: "Triggering pipelines with plugin"
         plugins:
-          - monebag/monorepo-diff#v2.5.8:
+          - buildkite-plugins/monorepo-diff#v1.0.1:
              watch:           
               - path: app/cms/
                 config: # Required [trigger step configuration]
@@ -75,7 +75,7 @@ Configuration supports 2 different step types.
       steps:
         - label: "Triggering pipelines"
           plugins:
-            - monebag/monorepo-diff#v2.5.8:
+            - buildkite-plugins/monorepo-diff#v1.0.1:
                 diff: "git diff --name-only HEAD~1"
                 watch:
                   - path: app/cms/
@@ -142,7 +142,7 @@ git diff --name-only "$LATEST_TAG"
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -166,7 +166,7 @@ The object values provided in this configuration will be appended to `env` prope
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "foo-service/"
@@ -188,7 +188,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -221,7 +221,7 @@ By setting `wait` to `true`, the build will wait until the triggered pipeline bu
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Configuration supports 2 different step types.
                 config: # Required [trigger step configuration]
                   trigger: cms-deploy # Required [trigger pipeline slug]
               - path:
-                  - services/email
+                  - services/email/
                   - assets/images/email
                 config:
                   trigger: email-deploy

--- a/README.md
+++ b/README.md
@@ -42,59 +42,67 @@ Configuration supports 2 different step types.
     
     
     **Example**
-    <br/>
-    When changes are detected in these paths of the monorepo, it triggers the other pipelines "cms-deploy" and "email-deploy"
+The  [**monorepo-diff buildkite plugin**](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin), triggers pipelines by watching folders in the monorepo. The configuration supports running [Command](https://buildkite.com/docs/pipelines/command-step) and [Trigger](https://buildkite.com/docs/pipelines/trigger-step) steps
 
-    ```yaml
-    steps:
-      - label: "Triggering pipelines with plugin"
-        plugins:
-          - buildkite-plugins/monorepo-diff#v1.0.1:
-             watch:           
-              - path: app/cms/
-                config: # Required [trigger step configuration]
-                  trigger: cms-deploy # Required [trigger pipeline slug]
-              - path:
-                  - services/email/
-                  - assets/images/email
-                config:
-                  trigger: email-deploy
-    ```
-      
-- [Command](https://buildkite.com/docs/pipelines/command-step)
-  
-    A `command` step runs one or more shell commands on one or more agents.
+<br/>
 
-
-    **Example**
-     <br/>
+ **Example 1**
+ <br/>
+ 
+ ```yaml
+ steps:
+   - label: "Triggering pipelines"
+     plugins:
+       - buildkite-plugins/monorepo-diff#v1.0.1:
+           diff: "git diff --name-only HEAD~1"
+           watch:
+             - path: app/
+               config:
+                 trigger: "app-deploy"
+             - path: test/bin/
+               config:
+                 command: "echo Make Changes to Bin"
+ ```
+ 
+ 
+ * Changes to the path `app/` triggers the pipeline `app-deploy`
+ * Changes to the path `test/bin` will run the respective configuration command
+ 
+ <br/>
+ 
+ ⚠️  Warning : The user has to explictly state the paths they want to monitor. For instance if a user,  is only watching path `app/` changes made to `app/bin` will not trigger the configuration. This is because the subfolder `/bin` was not specified.
+ 
+ <br/>
+ 
+  **Example 2**
+  <br/>
      
-     When changes are detected in these paths, it triggers other steps or pipelines with relevant commands, labels, and agent configurations 
-      
-  ```yaml
-      steps:
-        - label: "Triggering pipelines"
-          plugins:
-            - buildkite-plugins/monorepo-diff#v1.0.1:
-                diff: "git diff --name-only HEAD~1"
-                watch:
-                  - path: app/cms/
-                    config:
-                      group: ":rocket: deployment"
-                      command: "netlify --production deploy"
-                      label: ":netlify: Deploy to production"
-                      agents:
-                        queue: "deploy"
-                      env:
-                        - FOO=bar
-                  - path: app/service/
-                    config:
-                      command: "buildkite-agent pipeline upload ./frontend/.buildkite/pipeline.yaml"
-  
-  ```
-      
-  :warning: Warning: There is currently limited support for command configuration. Only the `command` property can be provided at this point in time. 
+ 
+ ```yaml
+     steps:
+       - label: "Triggering pipelines with plugin"
+         plugins:
+           - buildkite-plugins/monorepo-diff#v1.0.1:
+              watch:           
+               - path: test/.buildkite/
+                 config: # Required [trigger step configuration]
+                   trigger: test-pipeline # Required [trigger pipeline slug]
+               - path:
+                   - app/
+                   - app/bin/service/
+                 config:
+                     trigger: "data-generator"
+                     label: ":package: Generate data"
+                     build:
+                       meta_data:
+                         release-version: "1.1"
+ ```
+ 
+ * When changes are detected in the path `test/.buildkite/`  it triggers the pipeline `test-pipeline`
+ * If the changes are made to either `app/` or `app/bin/service/` it triggers the pipeline `data-generator`
+ 
 
+<br/>
 
 
 #### `diff` (optional)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,6 @@ services:
       dockerfile: ./tests/Dockerfile
   plugin_lint:
     image: buildkite/plugin-linter:latest
-    command: ['--id', 'monebag/monorepo-diff']
+    command: ['--id', 'buildkite-plugins/monorepo-diff']
     volumes:
       - ".:/plugin"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/monebag/monorepo-diff-buildkite-plugin
+module github.com/buildkite-plugins/monorepo-diff-buildkite-plugin
 
-go 1.19
+go 1.21.1
 
 require (
 	github.com/bmatcuk/doublestar/v2 v2.0.4

--- a/hooks/command
+++ b/hooks/command
@@ -65,15 +65,20 @@ downloader() {
   fi
 }
 
-
-
-download_binary_and_run() {
-  local _executable="monorepo-diff-buildkite-plugin"
-  local _repo="https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin"
-
+get_version() {
   local _plugin=${BUILDKITE_PLUGINS:-""}
   local _version=$(echo $_plugin | sed -e 's/.*monorepo-diff-buildkite-plugin//' -e 's/\".*//')
   RETVAL="$_version"
+}
+
+download_binary_and_run() {
+  get_architecture || return 1
+  local _arch="$RETVAL"
+  local _executable="monorepo-diff-buildkite-plugin"
+  local _repo="https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin"
+
+  get_version || return 1
+  local _version="$RETVAL"
 
   if [ -z ${_version} ]; then
     _url=${_repo}/releases/latest/download/${_executable}_${_arch}

--- a/hooks/command
+++ b/hooks/command
@@ -65,20 +65,15 @@ downloader() {
   fi
 }
 
-get_version() {
-  local _plugin=${BUILDKITE_PLUGINS:-""}
-  local _version=$(echo $_plugin | sed -e 's/.*monorepo-diff-buildkite-plugin//' -e 's/\".*//')
-  RETVAL="$_version"
-}
+
 
 download_binary_and_run() {
-  get_architecture || return 1
-  local _arch="$RETVAL"
   local _executable="monorepo-diff-buildkite-plugin"
   local _repo="https://github.com/monebag/monorepo-diff-buildkite-plugin"
 
-  get_version || return 1
-  local _version="$RETVAL"
+  local _plugin=${BUILDKITE_PLUGINS:-""}
+  local _version=$(echo $_plugin | sed -e 's/.*monorepo-diff-buildkite-plugin//' -e 's/\".*//')
+  RETVAL="$_version"
 
   if [ -z ${_version} ]; then
     _url=${_repo}/releases/latest/download/${_executable}_${_arch}

--- a/hooks/command
+++ b/hooks/command
@@ -69,7 +69,7 @@ downloader() {
 
 download_binary_and_run() {
   local _executable="monorepo-diff-buildkite-plugin"
-  local _repo="https://github.com/monebag/monorepo-diff-buildkite-plugin"
+  local _repo="https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin"
 
   local _plugin=${BUILDKITE_PLUGINS:-""}
   local _version=$(echo $_plugin | sed -e 's/.*monorepo-diff-buildkite-plugin//' -e 's/\".*//')

--- a/plugin.go
+++ b/plugin.go
@@ -8,7 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const pluginName = "github.com/monebag/monorepo-diff"
+const pluginName = "github.com/buildkite-plugins/monorepo-diff"
 
 // Plugin buildkite monorepo diff plugin structure
 type Plugin struct {

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: Monorepo Diff
 description: Trigger pipelines on changes in watched folders
-author: https://github.com/monebag
+author: https://github.com/buildkite-plugins
 requirements:
   - git
 configuration:

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -46,7 +46,7 @@ func TestPluginWithValidParameter(t *testing.T) {
 
 func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 	param := `[{
-		"github.com/monebag/monorepo-diff-buildkite-plugin#commit": {
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
 			"diff": "cat ./hello.txt",
 			"wait": true,
 			"log_level": "debug",
@@ -263,7 +263,7 @@ func TestPluginShouldOnlyFullyUnmarshallItselfAndNotOtherPlugins(t *testing.T) {
 			}
 		},
 		{
-			"github.com/monebag/monorepo-diff-buildkite-plugin#commit": {
+			"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
 				"watch": [
 					{
 						"env": [
@@ -289,7 +289,7 @@ func TestPluginShouldOnlyFullyUnmarshallItselfAndNotOtherPlugins(t *testing.T) {
 func TestPluginShouldErrorIfPluginConfigIsInvalid(t *testing.T) {
 	param := `[
 		{
-			"github.com/monebag/monorepo-diff-buildkite-plugin#commit": {
+			"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
 				"env": {
 					"anInvalidKey": "An Invalid Value"
 				},


### PR DESCRIPTION
Fully converted and tested [monorepo-diff-buildkite-plugin](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin). v1.0.1

## Why?

The plugin helps to reduce the complexities of tracking changes and dependencies across multiple repositories


## How to Test

1. Fork the [buildkite monorepo example](https://github.com/buildkite/monorepo-example/tree/stephanie-test)
2. Use the following pipeline.yml 


   ``` yaml
    steps:
      - label: "Triggering pipelines"
        plugins:
          - buildkite-plugins/monorepo-diff#v1.0.1:
              diff: "git diff --name-only HEAD~1"
              watch:
                - path: "app/src"
                  config:
                    command: "echo Hello World"
                - path: "test/"
                  config:
                    trigger: "test-pipeline"
    ```

3.   Configure webhooks for the mono repo using the payload URL from the pipeline settings
4.   Make changes to the folders watched in your pipeline configuration

## Changes

- Updated the README.md V1.0.1 (https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/2/commits/006e7707e1615164068e25e22e29ff573872296f)

- Updated the repository to buildkite-plugins on 
  -  command hook (https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/2/commits/e6c92d3b0704e2bf3efea6fbd1ba155aa30a92f3)
  - plugin.go, plugin.yml, plugin_test.go, go.mod, docker-compose.yml (https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/2/commits/c0eb03bb360ba1f5d2c78e91516a854f9ccbe209)