### PR TITLE
Update plugin path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Configuration supports 2 different step types.
     steps:
       - label: "Triggering pipelines with plugin"
         plugins:
-          - monebag/monorepo-diff#v2.5.8:
+          - buildkite-plugins/monorepo-diff#v1.0.1:
              watch:           
               - path: app/cms/
                 config: # Required [trigger step configuration]
@@ -75,7 +75,7 @@ Configuration supports 2 different step types.
       steps:
         - label: "Triggering pipelines"
           plugins:
-            - monebag/monorepo-diff#v2.5.8:
+            - buildkite-plugins/monorepo-diff#v1.0.1:
                 diff: "git diff --name-only HEAD~1"
                 watch:
                   - path: app/cms/
@@ -142,7 +142,7 @@ git diff --name-only "$LATEST_TAG"
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -166,7 +166,7 @@ The object values provided in this configuration will be appended to `env` prope
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "foo-service/"
@@ -188,7 +188,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -221,7 +221,7 @@ By setting `wait` to `true`, the build will wait until the triggered pipeline bu
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monebag/monorepo-diff#v2.5.8:
+      - buildkite-plugins/monorepo-diff#v1.0.1:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:


### PR DESCRIPTION
These updates simply point to the correct path in the Buildkite-plugins repo (instead of monebag).