### PR TITLE
fix: Allow empty generated pipelines to be skipped

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -206,7 +206,7 @@ func generatePipeline(steps []Step, plugin Plugin) (*os.File, bool, error) {
 	}
 
 	if err = ioutil.WriteFile(tmp.Name(), data, 0644); err != nil {
-		return nil, fmt.Errorf("could not write step to temporary file: %v", err)
+		return nil, false, fmt.Errorf("could not write step to temporary file: %v", err)
 	}
 
 	// Returns the temporary file and a boolean indicating whether or not the pipeline has steps

--- a/pipeline.go
+++ b/pipeline.go
@@ -40,7 +40,7 @@ func (n PluginNotify) MarshalYAML() (interface{}, error) {
 }
 
 // PipelineGenerator generates pipeline file
-type PipelineGenerator func(steps []Step, plugin Plugin) (*os.File, error)
+type PipelineGenerator func(steps []Step, plugin Plugin) (*os.File, bool, error)
 
 func uploadPipeline(plugin Plugin, generatePipeline PipelineGenerator) (string, []string, error) {
 	diffOutput, err := diff(plugin.Diff)
@@ -61,12 +61,18 @@ func uploadPipeline(plugin Plugin, generatePipeline PipelineGenerator) (string, 
 		return "", []string{}, err
 	}
 
-	pipeline, err := generatePipeline(steps, plugin)
+	pipeline, hasSteps, err := generatePipeline(steps, plugin)
 	defer os.Remove(pipeline.Name())
 
 	if err != nil {
 		log.Error(err)
 		return "", []string{}, err
+	}
+
+	if !hasSteps {
+		// Handle the case where no steps were provided
+		log.Info("No steps generated. Skipping pipeline upload.")
+		return "", []string{}, nil
 	}
 
 	cmd := "buildkite-agent"
@@ -156,10 +162,10 @@ func dedupSteps(steps []Step) []Step {
 	return unique
 }
 
-func generatePipeline(steps []Step, plugin Plugin) (*os.File, error) {
+func generatePipeline(steps []Step, plugin Plugin) (*os.File, bool, error) {
 	tmp, err := ioutil.TempFile(os.TempDir(), "bmrd-")
 	if err != nil {
-		return nil, fmt.Errorf("could not create temporary pipeline file: %v", err)
+		return nil, false, fmt.Errorf("could not create temporary pipeline file: %v", err)
 	}
 
 	yamlSteps := make([]yaml.Marshaler, len(steps))
@@ -191,7 +197,7 @@ func generatePipeline(steps []Step, plugin Plugin) (*os.File, error) {
 
 	data, err := yaml.Marshal(&pipeline)
 	if err != nil {
-		return nil, fmt.Errorf("could not serialize the pipeline: %v", err)
+		return nil, false, fmt.Errorf("could not serialize the pipeline: %v", err)
 	}
 
 	// Disable logging in context of go tests.
@@ -203,5 +209,10 @@ func generatePipeline(steps []Step, plugin Plugin) (*os.File, error) {
 		return nil, fmt.Errorf("could not write step to temporary file: %v", err)
 	}
 
-	return tmp, nil
+	// Returns the temporary file and a boolean indicating whether or not the pipeline has steps
+	if len(yamlSteps) == 0 {
+		return tmp, false, nil
+	} else {
+		return tmp, true, nil
+	}
 }

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func mockGeneratePipeline(steps []Step, plugin Plugin) (*os.File, error) {
+func mockGeneratePipeline(steps []Step, plugin Plugin) (*os.File, bool, error) {
 	mockFile, _ := os.Create("pipeline.txt")
 	defer mockFile.Close()
 
-	return mockFile, nil
+	return mockFile, true, nil
 }
 
 func TestUploadPipelineCallsBuildkiteAgentCommand(t *testing.T) {
@@ -37,6 +37,15 @@ func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T)
 func TestUploadPipelineCancelsIfThereIsNoDiffOutput(t *testing.T) {
 	plugin := Plugin{Diff: "echo"}
 	cmd, args, err := uploadPipeline(plugin, mockGeneratePipeline)
+
+	assert.Equal(t, "", cmd)
+	assert.Equal(t, []string{}, args)
+	assert.Equal(t, err, nil)
+}
+
+func TestUploadPipelineWithEmptyGeneratedPipeline(t *testing.T) {
+	plugin := Plugin{Diff: "echo ./bar-service"}
+	cmd, args, err := uploadPipeline(plugin, generatePipeline)
 
 	assert.Equal(t, "", cmd)
 	assert.Equal(t, []string{}, args)
@@ -274,7 +283,7 @@ func TestGeneratePipeline(t *testing.T) {
 		},
 	}
 
-	pipeline, err := generatePipeline(steps, plugin)
+	pipeline, _, err := generatePipeline(steps, plugin)
 
 	require.NoError(t, err)
 	defer os.Remove(pipeline.Name())
@@ -319,7 +328,7 @@ steps:
 	assert.Equal(t, want, string(got))
 }
 
-func TestGeneratePipelineWithNoSteps(t *testing.T) {
+func TestGeneratePipelineWithNoStepsAndHooks(t *testing.T) {
 	steps := []Step{}
 
 	want :=
@@ -337,7 +346,26 @@ func TestGeneratePipelineWithNoSteps(t *testing.T) {
 		},
 	}
 
-	pipeline, err := generatePipeline(steps, plugin)
+	pipeline, _, err := generatePipeline(steps, plugin)
+	require.NoError(t, err)
+	defer os.Remove(pipeline.Name())
+
+	got, err := ioutil.ReadFile(pipeline.Name())
+	require.NoError(t, err)
+
+	assert.Equal(t, want, string(got))
+}
+
+func TestGeneratePipelineWithNoStepsAndNoHooks(t *testing.T) {
+	steps := []Step{}
+
+	want :=
+		`steps: []
+`
+
+	plugin := Plugin{}
+
+	pipeline, _, err := generatePipeline(steps, plugin)
 	require.NoError(t, err)
 	defer os.Remove(pipeline.Name())
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -292,3 +292,31 @@ steps:
 - command: cat ./foo-file.txt
 EOM
 }
+
+@test "Pipeline is generated as empty" {
+  DIFF_CMD="echo bar-service/"
+  LOG_LEVEL="debug"
+
+  export BUILDKITE_PLUGINS='[{
+    "github.com/buildkite-plugins/monorepo-diff-buildkite-plugin": {
+      "diff":"echo bar-service/",
+      "log_level": "debug",
+      "watch": [
+        {
+          "path":"foo-service/",
+          "config": {
+            "trigger":"foo-service"
+          }
+        }
+      ]
+    }
+  }]'
+
+  run $PWD/hooks/command
+
+  assert_success
+
+  assert_output --partial << EOM
+steps: []
+EOM
+} 


### PR DESCRIPTION
If a generated pipeline has no steps generated, whether from the watched paths or via aspects of the plugin ie hooks, it fails. This PR solves that by skipping the upload step if the generated pipeline is empty. This is similar to the behaviour if there is no diff output.

In order to accomplish this, added a boolean to the output of generatePipeline() returning true if the generated pipeline has at least 1 step defined else returns false. This is then checked in uploadPipeline() and if the returned value was false ie there were no generated steps, uploadPipeline() returns without attempting to upload the empty pipeline.