### PR TITLE
Use a more portable shebang

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 check_cmd() {


### PR DESCRIPTION
## Changes

We have users looking at NixOS as an option for their agents. That tends to install bash at `/run/current-system/sw/bin/bash`.

`/bin/bash` isn't POSIX compliant, so Nix did add support for `/usr/bin/env` and `/bin/sh`

If we don't want to move to `/bin/sh` then `/usr/bin/env` would probably be the next best thing.