### PR TITLE
Escape pipeline interpolation

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,14 @@ steps:
       plugin-linter#v3.2.0:
         id: monorepo-diff
 
+  - label: ":golang: Test"
+    command: go test ./...
+    plugins:
+      - docker#v5.9.0:
+          image: "golang"
+          always-pull: true
+          workdir: /plugin
+  
   - label: ":linux: Build"
     command: make local
     artifact_paths: monorepo-diff-buildkite-plugin

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/bmatcuk/doublestar/v2 v2.0.4
+	github.com/buildkite/bintest v2.0.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/yaml.v2 v2.4.0
@@ -11,6 +12,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/lox/bintest v2.0.0+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.0.0-20220319134239-a9b59b0215f8 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,12 @@
 github.com/bmatcuk/doublestar/v2 v2.0.4 h1:6I6oUiT/sU27eE2OFcWqBhL1SwjyvQuOssxT4a1yidI=
 github.com/bmatcuk/doublestar/v2 v2.0.4/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
+github.com/buildkite/bintest v2.0.0+incompatible h1:efzz74HE4FsRPTWmynF9a51PdOP4BPCyTvb0QogSMUM=
+github.com/buildkite/bintest v2.0.0+incompatible/go.mod h1:2lGcuzwtlesvPHkylqPgQ0ytL6C5E6gjbb8o5ph583Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/lox/bintest v2.0.0+incompatible h1:tG24Y/co/JHWvy7wnPfkYp1Y1K5+bUex3PDMwJ7t3Ew=
+github.com/lox/bintest v2.0.0+incompatible/go.mod h1:mNlHbHtMU6Ang9ocdTOs3ZBJ12GsDaOdSKvGJL5gy2A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -22,7 +22,7 @@ func TestUploadPipelineCallsBuildkiteAgentCommand(t *testing.T) {
 
 	assert.Equal(t, "buildkite-agent", cmd)
 	assert.Equal(t, []string{"pipeline", "upload", "pipeline.txt"}, args)
-	assert.Equal(t, err.Error(), "command `buildkite-agent` failed: exec: \"buildkite-agent\": executable file not found in $PATH")
+	assert.Equal(t, "command `buildkite-agent` failed: exec: \"buildkite-agent\": executable file not found in $PATH", err.Error())
 }
 
 func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T) {
@@ -31,7 +31,7 @@ func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T)
 
 	assert.Equal(t, "buildkite-agent", cmd)
 	assert.Equal(t, []string{"pipeline", "upload", "pipeline.txt", "--no-interpolation"}, args)
-	assert.Equal(t, err.Error(), "command `buildkite-agent` failed: exec: \"buildkite-agent\": executable file not found in $PATH")
+	assert.Equal(t, "command `buildkite-agent` failed: exec: \"buildkite-agent\": executable file not found in $PATH", err.Error())
 }
 
 func TestUploadPipelineCancelsIfThereIsNoDiffOutput(t *testing.T) {
@@ -40,7 +40,7 @@ func TestUploadPipelineCancelsIfThereIsNoDiffOutput(t *testing.T) {
 
 	assert.Equal(t, "", cmd)
 	assert.Equal(t, []string{}, args)
-	assert.Equal(t, err, nil)
+	assert.Equal(t, nil, err)
 }
 
 func TestUploadPipelineWithEmptyGeneratedPipeline(t *testing.T) {
@@ -49,7 +49,7 @@ func TestUploadPipelineWithEmptyGeneratedPipeline(t *testing.T) {
 
 	assert.Equal(t, "", cmd)
 	assert.Equal(t, []string{}, args)
-	assert.Equal(t, err, nil)
+	assert.Equal(t, nil, err)
 }
 
 func TestDiff(t *testing.T) {

--- a/plugin.go
+++ b/plugin.go
@@ -259,17 +259,24 @@ func setNotify(notifications *[]StepNotify, rawNotify *[]map[string]interface{})
 	*rawNotify = nil
 }
 
+func escapeInterpolation(s string) string {
+	return strings.ReplaceAll(s, "$", "$$")
+}
+
 func setBuild(build *Build) {
+	// when defaulting to existing literal values make sure those values
+	// don't trigger interpolation with any stray dollar characters.
+
 	if build.Message == "" {
-		build.Message = env("BUILDKITE_MESSAGE", "")
+		build.Message = escapeInterpolation(env("BUILDKITE_MESSAGE", ""))
 	}
 
 	if build.Branch == "" {
-		build.Branch = env("BUILDKITE_BRANCH", "")
+		build.Branch = escapeInterpolation(env("BUILDKITE_BRANCH", ""))
 	}
 
 	if build.Commit == "" {
-		build.Commit = env("BUILDKITE_COMMIT", "")
+		build.Commit = escapeInterpolation(env("BUILDKITE_COMMIT", ""))
 	}
 }
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -123,7 +123,7 @@ EOM
 
 @test "Pipeline is generated with build config from env" {
   export BUILDKITE_BRANCH="go-rewrite"
-  export BUILDKITE_MESSAGE="some message"
+  export BUILDKITE_MESSAGE="some \$\$ message"
   export BUILDKITE_COMMIT="commit-hash"
 
   export BUILDKITE_PLUGINS='[{
@@ -149,7 +149,7 @@ EOM
 steps:
 - trigger: foo-service
   build:
-    message: some message
+    message: some \$\$\$\$ message
     branch: go-rewrite
     commit: commit-hash
 EOM


### PR DESCRIPTION
Currently, when a build message includes a dollar sign (`$`) and a trigger step is used then it causes an interpolation error:

<img width="821" alt="image" src="https://github.com/user-attachments/assets/756a1eaa-4278-4a14-880c-15de8f1384b2">

That's because the server side will do interpolation on values in uploaded yaml. So to survive that process any intended literal value should be escaped before upload.

This adds interpolation escaping to the literal values plucked from env to be included in pipeline yaml.

There might still be an issue when client-side interpolation is turned on. In that case the escaping might need to be done twice. But I'm considering that a separate issue.

I have no idea how to run these tests locally. The go tests seem to be broken, and/or require a docker-compose.yml which has been removed. The bats tests seem to need some sort of local `load.bash` library which I don't have on my system.

Fixes #15.