### PR TITLE
feat: add `skip_path` option in `watch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ It defines a list of paths or path to monitor for changes in the monorepo. It ch
 
 A path or a list of paths to be watched, This part specifies which directory should be monitored. It can also be a glob pattern. For example specify `path: "**/*.md"` to match all markdown files. A list of paths can be provided to trigger the desired pipeline or run command or even do a pipeline upload.
 
+#### `skip_path`
+
+A path or a list of paths to be ignored, which can be an exact path, or a glob.
+
+This is intended to be used in conjunction with `path`, and allows omitting specific paths from being matched.
+
 #### `config`
 
 This is a sub-section that provides configuration for running commands or triggering another pipeline when changes occur in the specified path

--- a/pipeline.go
+++ b/pipeline.go
@@ -112,10 +112,25 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 		for _, p := range w.Paths {
 			for _, f := range files {
 				match, err := matchPath(p, f)
+
+				skip := false
+				for _, sp := range w.SkipPaths {
+					skipMatch, errSkip := matchPath(sp, f)
+
+					if errSkip != nil {
+						return nil, errSkip
+					}
+
+					if skipMatch {
+						skip = true
+					}
+				}
+
 				if err != nil {
 					return nil, err
 				}
-				if match {
+
+				if match && !skip {
 					steps = append(steps, w.Step)
 					break
 				}

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -285,7 +285,93 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 				{Command: "buildkite-agent pipeline upload other_tests.yml"},
 			},
 		},
+		"skips service-2": {
+			ChangedFiles: []string{
+				"watch-path/text.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"watch-path"},
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths:     []string{"watch-path"},
+					SkipPaths: []string{"watch-path/text.txt"},
+					Step:      Step{Trigger: "service-2"},
+				}},
+			Expected: []Step{
+				{Trigger: "service-1"},
+			},
+		},
+		"skips extension wildcard": {
+			ChangedFiles: []string{
+				"text.secret.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"*.txt"},
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths:     []string{"*.txt"},
+					SkipPaths: []string{"*.secret.txt"},
+					Step:      Step{Trigger: "service-2"},
+				}},
+			Expected: []Step{
+				{Trigger: "service-1"},
+			},
+		},
+		"skips extension wildcard in subdir": {
+			ChangedFiles: []string{
+				"docs/text.secret.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"**/*.txt"},
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths:     []string{"**/*.txt"},
+					SkipPaths: []string{"docs/*.txt"},
+					Step:      Step{Trigger: "service-2"},
+				}},
+			Expected: []Step{
+				{Trigger: "service-1"},
+			},
+		},
+		"step is included even when one of the files is skipped": {
+			ChangedFiles: []string{
+				"docs/text.secret.txt",
+				"docs/text.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"**/*.txt"},
+					Step:  Step{Trigger: "service-1"},
+				},
+				{
+					Paths:     []string{"**/*.txt"},
+					SkipPaths: []string{"docs/*.secret.txt"},
+					Step:      Step{Trigger: "service-2"},
+				}},
+			Expected: []Step{
+				{Trigger: "service-1"},
+				{Trigger: "service-2"},
+			},
+		},
+		"fails if not path is included": {
+			ChangedFiles: []string{
+				"docs/text.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					SkipPaths: []string{"docs/*.secret.txt"},
+					Step:      Step{Trigger: "service-1"},
+				}},
+			Expected: []Step{},
+		},
 	}
+
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			steps, err := stepsToTrigger(tc.ChangedFiles, tc.WatchConfigs)

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -242,6 +242,23 @@ EOM
           "config": {
             "command": ["echo one", "echo two"]
           }
+        },
+        {
+          "path": "**/*.md",
+          "skip_path": "**/*.secret.md",
+          "config": {
+            "trigger": "markdown-pipeline"
+          }
+        },
+        {
+          "path": "**/*.md",
+          "skip_path": [
+            "**/*.secret.md",
+            "CONTRIBUTING.md",
+          ],
+          "config": {
+            "trigger": "markdown-pipeline"
+          }
         }
       ]
     }


### PR DESCRIPTION
This PR adds support for specifying a `skip_path` option that support either a path or a list of paths that shouldn't result in adding the `trigger` step as part of the dynamically generated pipeline.

Note even in cases where a line in the `diff` is skipped due to `skip_path` and there are other paths in the `diff` that match `path` but doesn't match `skip_path`, the step will still be added to the dynamically generated pipeline. i.e. for the step to be effectively ignored, the paths in `skip_path` should match all of those in the given `diff`.

## Motivation

The motivation for this is the lack of support for negation cases in `doublestar` (the package used for glob pattern matching) See https://github.com/bmatcuk/doublestar/issues/49. 

I had a use case where I needed to avoid changes in certain subdirectories to trigger a step (if there were the only changes in the diff) and I tried to use the following pattern: `path: "/main/{*,!(subdir1|subdir2)/**/*}"` which should be a valid glob for filtering out `subdir1` and `subdir2`, but didn't work.

With this, I could instead do something like:

```yml
- path: "main/"
  skip_path:
    - "main/subdir1"
    - "main/subdir2"
```

and the result would be the same.

---

This is a `git cherry-pick` from https://github.com/adikari/monorepo-diff-buildkite-plugin/pull/88

This will close #20.
