### PR TITLE
Support using default config on no path match

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -147,3 +147,31 @@ steps:
               config:
                 group: "this is a group"
                 command: "echo this-does-not-run"
+  - labeL: ":testtube: Testing default config"
+    plugins:
+      - artifacts#v1.9.2:
+          download:
+            - "monorepo-diff-buildkite-plugin"
+      - monorepo-diff#${BUILDKITE_COMMIT}:
+          diff: "cat ./e2e/commands-or-triggers"
+          watch:
+            - path: "not_a_path/"
+              config:
+                command: echo "This shouldn't run"
+            - default:
+                command: "echo hello-world"
+
+  - labeL: ":testtube: Testing default config with map"
+    plugins:
+      - artifacts#v1.9.2:
+          download:
+            - "monorepo-diff-buildkite-plugin"
+      - monorepo-diff#${BUILDKITE_COMMIT}:
+          diff: "cat ./e2e/commands-or-triggers"
+          watch:
+            - path: "not_a_path/"
+              config:
+                command: echo "This shouldn't run"
+            - default:
+              config:
+                command: "echo hello-world"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -147,7 +147,8 @@ steps:
               config:
                 group: "this is a group"
                 command: "echo this-does-not-run"
-  - labeL: ":testtube: Testing default config"
+
+  - label: ":testtube: Testing default config"
     plugins:
       - artifacts#v1.9.2:
           download:
@@ -161,7 +162,7 @@ steps:
             - default:
                 command: "echo hello-world"
 
-  - labeL: ":testtube: Testing default config with map"
+  - label: ":testtube: Testing default config with map"
     plugins:
       - artifacts#v1.9.2:
           download:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -174,5 +174,5 @@ steps:
               config:
                 command: echo "This shouldn't run"
             - default:
-              config:
-                command: "echo hello-world"
+                config:
+                  command: "echo hello-world"

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Configuration supports 2 different step types.
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.0.1:
+      - monorepo-diff#v1.1.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: app/
@@ -70,7 +70,7 @@ steps:
 steps:
   - label: "Triggering pipelines with plugin"
     plugins:
-      - monorepo-diff#v1.0.1:
+      - monorepo-diff#v1.1.0:
           watch:
             - path: test/.buildkite/
               config: # Required [trigger step configuration]
@@ -137,7 +137,7 @@ git diff --name-only "$LATEST_TAG"
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.0.1:
+      - monorepo-diff#v1.1.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -164,7 +164,7 @@ A default `config` to run if no paths are matched, the `config` key is not reuir
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.0.1:
+      - monorepo-diff#v1.1.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -186,7 +186,7 @@ The object values provided in this configuration will be appended to `env` prope
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.0.1:
+      - monorepo-diff#v1.1.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "foo-service/"
@@ -208,7 +208,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.0.1:
+      - monorepo-diff#v1.1.0:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -239,7 +239,7 @@ By setting `wait` to `true`, the build will wait until the triggered pipeline bu
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.0.1:
+      - monorepo-diff#v1.1.0:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,30 @@ This controls the pipeline interpolation on upload, and defaults to `true`.
 If set to `false` it adds `--no-interpolation` to the `buildkite pipeline upload`,
 to avoid trying to interpolate the commit message, which can cause failures.
 
+#### `default` (optional)
+
+A default `config` to run if no paths are matched, the `config` key is not reuired, so a `default` can be written with a `config` attribute or simple just a `command` or `trigger`.
+
+**Example**
+
+```yaml
+steps:
+  - label: "Triggering pipelines"
+    plugins:
+      - monorepo-diff#v1.0.1:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "bar-service/"
+              config:
+                command: "echo deploy-bar"
+            - path: "foo-service/"
+              config:
+                trigger: "deploy-foo-service"
+            - default: 
+                config: ## <-- Optional
+                  command: echo "Hello, world!"
+```
+
 #### `env` (optional)
 
 The object values provided in this configuration will be appended to `env` property of all steps or commands.

--- a/e2e/commands-or-triggers
+++ b/e2e/commands-or-triggers
@@ -2,3 +2,4 @@ user-service/infrastructure/cloudfront.yaml
 user-service/serverless.yaml
 world/bin/cli
 global/route53.yaml
+unfound/file.ps1

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ func setupLogger(logLevel string) {
 	})
 
 	ll, err := log.ParseLevel(logLevel)
-
 	if err != nil {
 		ll = log.InfoLevel
 	}
@@ -29,7 +28,6 @@ func main() {
 	log.Debugf("received plugin: \n%v", plugins)
 
 	plugin, err := initializePlugin(plugins)
-
 	if err != nil {
 		log.Debug(err)
 		log.Fatal(err)

--- a/pipeline.go
+++ b/pipeline.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strings"
@@ -94,7 +93,6 @@ func diff(command string) ([]string, error) {
 		env("SHELL", "bash"),
 		[]string{"-c", strings.Replace(command, "\n", " ", -1)},
 	)
-
 	if err != nil {
 		return nil, fmt.Errorf("diff command failed: %v", err)
 	}
@@ -107,7 +105,7 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 	var defaultStep *Step
 
 	for _, w := range watch {
-		if w.Default {
+		if w.Default != nil {
 			defaultStep = &w.Step
 			continue
 		}
@@ -172,7 +170,7 @@ func dedupSteps(steps []Step) []Step {
 }
 
 func generatePipeline(steps []Step, plugin Plugin) (*os.File, bool, error) {
-	tmp, err := ioutil.TempFile(os.TempDir(), "bmrd-")
+	tmp, err := os.CreateTemp(os.TempDir(), "bmrd-")
 	if err != nil {
 		return nil, false, fmt.Errorf("could not create temporary pipeline file: %v", err)
 	}
@@ -214,7 +212,7 @@ func generatePipeline(steps []Step, plugin Plugin) (*os.File, bool, error) {
 		fmt.Printf("Generated Pipeline:\n%s\n", string(data))
 	}
 
-	if err = ioutil.WriteFile(tmp.Name(), data, 0644); err != nil {
+	if err = os.WriteFile(tmp.Name(), data, 0o644); err != nil {
 		return nil, false, fmt.Errorf("could not write step to temporary file: %v", err)
 	}
 

--- a/pipeline.go
+++ b/pipeline.go
@@ -104,8 +104,13 @@ func diff(command string) ([]string, error) {
 
 func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 	steps := []Step{}
+	var defaultStep *Step
 
 	for _, w := range watch {
+		if w.Default {
+			defaultStep = &w.Step
+			continue
+		}
 		for _, p := range w.Paths {
 			for _, f := range files {
 				match, err := matchPath(p, f)
@@ -118,6 +123,10 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 				}
 			}
 		}
+	}
+
+	if len(steps) == 0 && defaultStep != nil {
+		steps = append(steps, *defaultStep)
 	}
 
 	return dedupSteps(steps), nil

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -231,6 +231,28 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 				{Trigger: "txt"},
 			},
 		},
+		"default configuration": {
+			ChangedFiles: []string{
+				"unmatched/file.txt",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths: []string{"app/"},
+					Step:  Step{Trigger: "app-deploy"},
+				},
+				{
+					Paths: []string{"test/bin/"},
+					Step:  Step{Command: "echo Make Changes to Bin"},
+				},
+				{
+					Default: true,
+					Step:    Step{Command: "echo Default action"},
+				},
+			},
+			Expected: []Step{
+				{Command: "echo Default action"},
+			},
+		},
 	}
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -121,7 +120,6 @@ func TestPipelinesToTriggerGetsListOfPipelines(t *testing.T) {
 }
 
 func TestPipelinesStepsToTrigger(t *testing.T) {
-
 	testCases := map[string]struct {
 		ChangedFiles []string
 		WatchConfigs []WatchConfig
@@ -245,12 +243,12 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 					Step:  Step{Command: "echo Make Changes to Bin"},
 				},
 				{
-					Default: true,
-					Step:    Step{Command: "echo Default action"},
+					Default: struct{}{},
+					Step:    Step{Command: "buildkite-agent pipeline upload other_tests.yml"},
 				},
 			},
 			Expected: []Step{
-				{Command: "echo Default action"},
+				{Command: "buildkite-agent pipeline upload other_tests.yml"},
 			},
 		},
 	}
@@ -310,11 +308,10 @@ func TestGeneratePipeline(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(pipeline.Name())
 
-	got, err := ioutil.ReadFile(pipeline.Name())
+	got, err := os.ReadFile(pipeline.Name())
 	require.NoError(t, err)
 
-	want :=
-		`notify:
+	want := `notify:
 - email: foo@gmail.com
 - email: bar@gmail.com
 - basecamp_campfire: https://basecamp
@@ -353,8 +350,7 @@ steps:
 func TestGeneratePipelineWithNoStepsAndHooks(t *testing.T) {
 	steps := []Step{}
 
-	want :=
-		`steps:
+	want := `steps:
 - wait: null
 - command: echo "hello world"
 - command: cat ./file.txt
@@ -372,7 +368,7 @@ func TestGeneratePipelineWithNoStepsAndHooks(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(pipeline.Name())
 
-	got, err := ioutil.ReadFile(pipeline.Name())
+	got, err := os.ReadFile(pipeline.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, want, string(got))
@@ -381,8 +377,7 @@ func TestGeneratePipelineWithNoStepsAndHooks(t *testing.T) {
 func TestGeneratePipelineWithNoStepsAndNoHooks(t *testing.T) {
 	steps := []Step{}
 
-	want :=
-		`steps: []
+	want := `steps: []
 `
 
 	plugin := Plugin{}
@@ -391,7 +386,7 @@ func TestGeneratePipelineWithNoStepsAndNoHooks(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(pipeline.Name())
 
-	got, err := ioutil.ReadFile(pipeline.Name())
+	got, err := os.ReadFile(pipeline.Name())
 	require.NoError(t, err)
 
 	assert.Equal(t, want, string(got))

--- a/plugin.go
+++ b/plugin.go
@@ -34,6 +34,7 @@ type WatchConfig struct {
 	RawPath interface{} `json:"path"`
 	Paths   []string
 	Step    Step `json:"config"`
+	Default bool `json:"default"`
 }
 
 type Group struct {
@@ -124,12 +125,16 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 	// Path can be string or an array of strings,
 	// handle both cases and create an array of paths.
 	for i, p := range plugin.Watch {
-		switch p.RawPath.(type) {
-		case string:
-			plugin.Watch[i].Paths = []string{plugin.Watch[i].RawPath.(string)}
-		case []interface{}:
-			for _, v := range plugin.Watch[i].RawPath.([]interface{}) {
-				plugin.Watch[i].Paths = append(plugin.Watch[i].Paths, v.(string))
+		if p.Default {
+			plugin.Watch[i].Paths = []string{"*"}
+		} else if p.RawPath != nil {
+			switch p.RawPath.(type) {
+			case string:
+				plugin.Watch[i].Paths = []string{plugin.Watch[i].RawPath.(string)}
+			case []interface{}:
+				for _, v := range plugin.Watch[i].RawPath.([]interface{}) {
+					plugin.Watch[i].Paths = append(plugin.Watch[i].Paths, v.(string))
+				}
 			}
 		}
 

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -138,6 +138,11 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						],
 						"soft_fail": true
 					}
+				},
+				{
+					"default": {
+                        "command": "buildkite-agent pipeline upload other_tests.yml"
+                    }
 				}
 			]
 		}
@@ -242,6 +247,15 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"hi":   "bye",
 					},
 					SoftFail: true,
+				},
+			},
+			{
+				Default: map[string]interface{}{
+					"command": "buildkite-agent pipeline upload other_tests.yml",
+				},
+				Paths: []string{},
+				Step: Step{
+					Command: "buildkite-agent pipeline upload other_tests.yml",
 				},
 			},
 		},

--- a/util.go
+++ b/util.go
@@ -43,9 +43,9 @@ func isString(val interface{}) (string, bool) {
 		return "", false
 	}
 
-	switch val.(type) {
+	switch val := val.(type) {
 	case string:
-		return val.(string), true
+		return val, true
 	}
 
 	return "", false


### PR DESCRIPTION
## Changes

Issue [#23](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/issues/23) raises a good point of having a default config, which may be a nice addition to the plugin and allow folks to not have to cover all bases to run a config (`command` or `trigger`)

- Supports a `default` config in the plugin

This can be used as either:

```yaml
    ...
        - default:
            config:
              command: buildkite-agent pipeline upload other_tests.yml
    ...
```

or:

```yaml
    ...
        - default:
            trigger: cool-pipeline
    ...
```

- Added tests to cover the cases where default may be used
