### PR TITLE
Fix default env test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/bmatcuk/doublestar/v2 v2.0.4
 	github.com/buildkite/bintest v2.0.0+incompatible
+	github.com/google/go-cmp v0.6.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/buildkite/bintest v2.0.0+incompatible/go.mod h1:2lGcuzwtlesvPHkylqPgQ
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/lox/bintest v2.0.0+incompatible h1:tG24Y/co/JHWvy7wnPfkYp1Y1K5+bUex3PDMwJ7t3Ew=
 github.com/lox/bintest v2.0.0+incompatible/go.mod h1:mNlHbHtMU6Ang9ocdTOs3ZBJ12GsDaOdSKvGJL5gy2A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -261,7 +262,9 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, expected, got)
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Fatalf("plugin diff (-want +got): \n%s", diff)
+	}
 }
 
 func TestPluginShouldOnlyFullyUnmarshallItselfAndNotOtherPlugins(t *testing.T) {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -142,8 +142,8 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 				},
 				{
 					"default": {
-                        "command": "buildkite-agent pipeline upload other_tests.yml"
-                    }
+						"command": "buildkite-agent pipeline upload other_tests.yml"
+					}
 				}
 			]
 		}
@@ -257,6 +257,11 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 				Paths: []string{},
 				Step: Step{
 					Command: "buildkite-agent pipeline upload other_tests.yml",
+					Env: map[string]string{
+						"env1": "env-1",
+						"env2": "env-2",
+						"env3": "env-3",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
The go tests on master are broken. It looks like the default command was taught to inherit the global env (part of buildkite-plugins/monorepo-diff-buildkite-plugin#29) but the test doesn't agree. Also swaps equals to diff cmp (thanks @moskyb) to more easily identify where in the deep structure is different.