### PR TITLE
feat: preserve `plugins:` blocks in watched steps

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -81,6 +81,7 @@ type Step struct {
 	Agents    Agent                    `yaml:"agents,omitempty"`
 	Artifacts []string                 `yaml:"artifacts,omitempty"`
 	RawEnv    interface{}              `json:"env" yaml:",omitempty"`
+	Plugins   []map[string]interface{} `json:"plugins,omitempty" yaml:"plugins,omitempty"`
 	Env       map[string]string        `yaml:"env,omitempty"`
 	Async     bool                     `yaml:"async,omitempty"`
 	SoftFail  interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`


### PR DESCRIPTION
This change adds support for arbitrary **plugins** blocks within watched step configs:

```yaml
steps:
  - label: "Run Changed Workflows"
    plugins:
      - monorepo-diff#v1.3.0:
          diff: "git diff --name-only origin/main...HEAD"
          watch:
            - path: "src/**"
              config:
                label: "Run Tests"
                plugins:
                  - docker#v5.12.0:
                      image: "myorg/test-runner:latest"
                  - slack#v3.1.0:
                      channel: "#ci-notifications"
```

Previously only **command** and **trigger** were retained, causing nested plugins to be stripped out.

Key changes:

- Extend the Step struct to include a Plugins field and marshal it to YAML
- Add a new integration test

