### PR TITLE
fix: nested envs parsing as rawenv

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -28,8 +28,8 @@ func TestUploadPipelineCallsBuildkiteAgentCommand(t *testing.T) {
 	}
 
 	oldPath := os.Getenv("PATH")
-	t.Cleanup(func() { os.Setenv("PATH", oldPath) })
-	os.Setenv("PATH", filepath.Dir(agent.Path)+":"+oldPath)
+	t.Cleanup(func() { _ = os.Setenv("PATH", oldPath) })
+	_ = os.Setenv("PATH", filepath.Dir(agent.Path)+":"+oldPath)
 
 	agent.
 		Expect("pipeline", "upload", "pipeline.txt").
@@ -55,8 +55,8 @@ func TestUploadPipelineCallsBuildkiteAgentCommandWithInterpolation(t *testing.T)
 	}
 
 	oldPath := os.Getenv("PATH")
-	t.Cleanup(func() { os.Setenv("PATH", oldPath) })
-	os.Setenv("PATH", filepath.Dir(agent.Path)+":"+oldPath)
+	t.Cleanup(func() { _ = os.Setenv("PATH", oldPath) })
+	_ = os.Setenv("PATH", filepath.Dir(agent.Path)+":"+oldPath)
 
 	agent.
 		Expect("pipeline", "upload", "pipeline.txt", "--no-interpolation").
@@ -459,7 +459,7 @@ func TestGeneratePipeline(t *testing.T) {
 
 	require.NoError(t, err)
 	defer func() {
-		if err := os.Remove(pipeline.Name()); err != nil {
+		if err = os.Remove(pipeline.Name()); err != nil {
 			t.Logf("Failed to remove temporary pipeline file: %v", err)
 		}
 	}()
@@ -522,7 +522,11 @@ func TestGeneratePipelineWithNoStepsAndHooks(t *testing.T) {
 
 	pipeline, _, err := generatePipeline(steps, plugin)
 	require.NoError(t, err)
-	defer os.Remove(pipeline.Name())
+	defer func() {
+		if err = os.Remove(pipeline.Name()); err != nil {
+			t.Logf("failed to remove teme file: %v", err)
+		}
+	}()
 
 	got, err := os.ReadFile(pipeline.Name())
 	require.NoError(t, err)
@@ -540,7 +544,11 @@ func TestGeneratePipelineWithNoStepsAndNoHooks(t *testing.T) {
 
 	pipeline, _, err := generatePipeline(steps, plugin)
 	require.NoError(t, err)
-	defer os.Remove(pipeline.Name())
+	defer func() {
+		if err = os.Remove(pipeline.Name()); err != nil {
+			t.Logf("Failed to remove temporary pipeline file: %v", err)
+		}
+	}()
 
 	got, err := os.ReadFile(pipeline.Name())
 	require.NoError(t, err)
@@ -573,7 +581,11 @@ func TestGeneratePipelineWithCondition(t *testing.T) {
 
 	pipeline, _, err := generatePipeline(steps, plugin)
 	require.NoError(t, err)
-	defer os.Remove(pipeline.Name())
+	defer func() {
+		if err = os.Remove(pipeline.Name()); err != nil {
+			t.Logf("Failed to remove temporary pipeline file: %v", err)
+		}
+	}()
 
 	got, err := os.ReadFile(pipeline.Name())
 	require.NoError(t, err)


### PR DESCRIPTION
## Problem

Currently, something like this will cause an incorrectly parsed pipeline:

```yaml
steps:
  - label: "Determine which sub build to trigger"
    plugins:
    - monorepo-diff#v1.5.0:
        diff: ".buildkite/scripts/diff_against_base_branch.sh"
        watch:
          - path: 
            - 'yarn.lock'
            config:
              group: "group"
              steps:
                - trigger: "${BUILDKITE_PIPELINE_SLUG}"
                  label: "PR build"
                  build:
                    commit: "${BUILDKITE_COMMIT}"
                    branch: "$BUILDKITE_BRANCH"
                    env:
                      - BUNDLE_BUILD=pr

                - trigger: "${BUILDKITE_PIPELINE_SLUG}"
                  label: "Master build"
                  build:
                    branch: "master"
                    env:
                      - BUNDLE_BUILD=master
```

Becomes:

```yaml
    - group: group
      steps:
        - trigger: dash-bundle-check
          label: 'PR build'
          build:
            branch: branch
            commit: commit
            rawenv:
                - BUNDLE_BUILD=pr
        - trigger: dash-bundle-check
          label: 'Master build'
          build:
            branch: master
            rawenv:
                - BUNDLE_BUILD=master
```

This is due to the way we're parsing (or not parsing) steps.Steps values.

## Changes

- We now correctly parse `steps.Steps` values so that nested step `env` variables will parse as `env` rather than `rawenv`
- Added a test
- Fixed some linting issues with `errcheck` failures
