### PR TITLE
feat: add support for depends_on in step definitions

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -93,6 +93,7 @@ type Step struct {
 	SoftFail  interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`
 	RawNotify []map[string]interface{} `json:"notify" yaml:",omitempty"`
 	Notify    []StepNotify             `yaml:"notify,omitempty"`
+	DependsOn interface{}              `json:"depends_on" yaml:"depends_on,omitempty"`
 	Steps     []Step                   `yaml:"steps,omitempty"`
 }
 


### PR DESCRIPTION
## Summary
Adds support for the Buildkite `depends_on` key in step configurations. The `depends_on` field can be specified as either a single string or an array of strings, matching Buildkite's native pipeline YAML format.

Closes #124

## Changes
- Added `DependsOn` field to `Step` struct with `interface{}` type to support both string and array values
- Added comprehensive tests for parsing `depends_on` from plugin configuration
- Added pipeline generation test to verify correct YAML output format
- All existing tests continue to pass (83.3% coverage)

## Test plan
- [x] Added unit tests for string `depends_on` values (`TestPluginShouldPreserveDependsOnString`)
- [x] Added unit tests for array `depends_on` values (`TestPluginShouldPreserveDependsOnArray`)
- [x] Added pipeline generation test (`TestGeneratePipelineWithDependsOn`)
- [x] All tests passing: `make test`
- [x] Code quality checks passing: `make quality`

## Example Usage

Single dependency:
```yaml
watch:
  - path: "service/**/*"
    config:
      command: "echo deploy"
      depends_on: "build-step"
```

Multiple dependencies:
```yaml
watch:
  - path: "service/**/*"
    config:
      trigger: "deploy-pipeline"
      depends_on:
        - "build-step"
        - "test-step"
```