### PR TITLE
Fix unicode handling in git diff output

### DIFF
--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -119,6 +119,34 @@ func TestDiffWithSubshell(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestDiffWithQuotedPaths(t *testing.T) {
+	want := []string{
+		"projects/test/pages/17_🪁_testfile.py",
+		"normal/file.txt",
+	}
+	got, err := diff(`printf '"projects/test/pages/17_\360\237\252\201_testfile.py" normal/file.txt'`)
+	assert.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestStepsToTriggerWithEmojiPaths(t *testing.T) {
+	watch := []WatchConfig{
+		{
+			Paths: []string{"projects/**"},
+			Step:  Step{Trigger: "test-pipeline"},
+		},
+	}
+
+	changedFiles := []string{
+		"projects/test/pages/17_🪁_testfile.py",
+		"other/file.txt",
+	}
+
+	steps, err := stepsToTrigger(changedFiles, watch)
+	assert.NoError(t, err)
+	assert.Equal(t, []Step{{Trigger: "test-pipeline"}}, steps)
+}
+
 func TestPipelinesToTriggerGetsListOfPipelines(t *testing.T) {
 	want := []string{"service-1", "service-2", "service-4"}
 


### PR DESCRIPTION
When git encounters unicode characters in filenames, it uses C-style quoting with octal sequences, e.g.:
`src/17_\360\237\252\201_testfile.py`.

The `diff()` function was using `strings.Fields()` to split git output which preserves the quotes around the path. When matching against patterns like `projects/<kite>/**`, comparison fails due to path string including surrounding quotes leaving escape sequences uninterpreted.

The fix checks each field from git diff output, and if it's quoted, it uses `strconv.Unqoute()` to remove quote and decode escape sequences into Unicode characters.

Also, added tests to verify that quoted paths are decoded correctly (TestDiffWithQuotedPaths), and test for pattern matching (TestStepsToTriggerWithEmojiPaths).

Fixes https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/issues/128