### PR TITLE
Bring Changelog UTD and bump README versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,53 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.6.0]
+
+### Added
+* Add support for `key` in watch config steps by @toadzky in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/133
+
+### Changed
+* Perform an update check instead of downloading the binary every run by @JanSF in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/127
+
+## [v1.5.2]
+
+### Added
+* Add support for `depends_on` in step definitions by @jasonwbarnett in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/123
+
+### Changed
+* Perform an update check instead of downloading the binary every run by @JanSF in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/122
+* Revert the update check change by @pzeballos in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/126
+* Maintenance updates to Go/tooling dependencies by @renovate[bot]
+
+### Fixed
+* Fix unicode handling in git diff output by @scadu in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/131
+
+## [v1.5.1]
+
+### Fixed
+* Fix nested envs parsing as rawenv by @mcncl in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/108
+
+## [v1.5.0]
+
+### Added
+* Add env and metadata attributes to steps by @jykingston in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/74
+* Add compatibility table by @mcncl in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/81
+* Add OSSF scanning by @mcncl in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/90
+* Add support for conditionals (`if`) in steps by @jasonwbarnett in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/92
+
+## [v1.4.0]
+
+### Added
+* Preserve `plugins:` blocks in watched steps by @dstrates in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/50
+* Support `branches` in steps by @toote in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/52
+* Support multiple steps by @toote in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/53
+* Add `except_path` functionality by @lswith in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/72
+
+### Changed
+* Reconfigure tests and remove BATS by @petetomasik in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/48
+* Update dependencies by @toote in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/73
+* Remove pull request action by @pzeballos in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/70
+* Update broken link to original author by @adikari in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/49
 
 ## [v1.3.0]
 
@@ -29,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.1.0]
 
 ### Fixed
-* Updates to CI, testing and bug fixes by @pzeballos in #7 
+* Updates to CI, testing and bug fixes by @pzeballos in #7
 * Fix default env test by @sj26 in https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/33
 
 ### Changed
@@ -46,4 +92,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v1.0.0]
 
 ### Changed
-* Update to README.md  ([#1](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/1)) @stephanieatte 
+* Update to README.md  ([#1](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/pull/1)) @stephanieatte

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For example, in the following configuration:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "**/*"
@@ -78,7 +78,7 @@ This is a sub-section that provides configuration for running commands or trigge
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           watch:
             - path: app/
               config:
@@ -109,7 +109,7 @@ steps:
 steps:
   - label: "Triggering pipelines with plugin"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           watch:
             - path: test/.buildkite/
               config: # Required [trigger step configuration]
@@ -138,7 +138,7 @@ The plugin supports conditional execution of pipeline steps using the `if` key, 
 steps:
   - label: "Triggering pipelines with plugin"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: git diff --name-only HEAD~1
           watch:
             - path: services/api
@@ -201,7 +201,7 @@ git diff --name-only "$LATEST_TAG"
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -228,7 +228,7 @@ A default `config` to run if no paths are matched, the `config` key is not requi
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -250,7 +250,7 @@ The object values provided in this configuration will be appended to `env` prope
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "foo-service/"
@@ -272,7 +272,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -305,7 +305,7 @@ Add `key` to set the step or group key.
 steps:
   - label: "Setting Key"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -320,7 +320,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.5.2:
+      - monorepo-diff#v1.6.0:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:


### PR DESCRIPTION
Bumps latest version in README to v1.6.0 and brings Changelog up to date as there's been quite a few releases that haven't been included