### PR TITLE
feat(group): support key attribute on group steps

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -31,12 +31,14 @@ func (s Step) MarshalYAML() (interface{}, error) {
 	}
 
 	label := s.Group
+	key := s.Key
 	s.Group = ""
+	s.Key = ""
 	stps := []Step{s}
 	if s.Steps != nil {
 		stps = s.Steps
 	}
-	return Group{Label: label, Steps: stps}, nil
+	return Group{Label: label, Key: key, Steps: stps}, nil
 }
 
 func (n PluginNotify) MarshalYAML() (interface{}, error) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -998,6 +998,34 @@ func TestGeneratePipelineWithNotifyInGroup(t *testing.T) {
 	validatePipelineWithAgent(t, tmp.Name())
 }
 
+func TestGeneratePipelineWithKeyInGroup(t *testing.T) {
+	steps := []Step{{
+		Group: "Test Group",
+		Key:   "test-group",
+		Steps: []Step{{
+			Label:   "Run Tests",
+			Command: "echo 'test'",
+		}},
+	}}
+
+	plugin := Plugin{}
+
+	tmp, hasPipeline, err := generatePipeline(steps, plugin)
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+
+	output := string(content)
+	assert.Contains(t, output, "group: Test Group")
+	assert.Contains(t, output, "key: test-group")
+	assert.Contains(t, output, "label: Run Tests")
+
+	validatePipelineWithAgent(t, tmp.Name())
+}
+
 func TestGeneratePipelineWithPlugins(t *testing.T) {
 	steps := []Step{
 		{

--- a/plugin.go
+++ b/plugin.go
@@ -47,6 +47,7 @@ type WatchConfig struct {
 
 type Group struct {
 	Label string `yaml:"group"`
+	Key   string `yaml:"key,omitempty"`
 	Steps []Step `yaml:"steps"`
 }
 


### PR DESCRIPTION
# Overview

The Buildkite group step spec includes `key` as a valid attribute, allowing other steps to declare a dependency on an entire group via `depends_on`. This attribute was not being serialised into the generated pipeline YAML, making group-level dependencies impossible to use with this plugin.

Fixes #170 

# Changes

- Added `key` field support on group steps — the value is now serialised at the group level in the generated YAML, enabling `depends_on` references to groups
- Added test coverage for group steps with a `key` attribute

# Test Plan

- [x] `go test ./...`
- [x] Validated end-to-end via a release of a forked version ([JonCubed/monorepo-diff-buildkite-plugin@v1.9.2](https://github.com/JonCubed/monorepo-diff-buildkite-plugin/releases/tag/v1.9.2)) — confirmed `key` appears at the group level in the generated pipeline YAML