### PR TITLE
fix: support plugin-only steps in monorepo-diff watch config

### DIFF
--- a/pipeline.go
+++ b/pipeline.go
@@ -191,10 +191,10 @@ func logInvalidStep(step Step) {
 			context = fmt.Sprintf("group '%s' has invalid nested steps", step.Group)
 		}
 	} else if step.Label != "" {
-		context = fmt.Sprintf("step with label '%s' has no command, trigger, or group", step.Label)
+		context = fmt.Sprintf("step with label '%s' has no command, trigger, plugins, or group", step.Label)
 	}
 
-	log.Warnf("Skipping invalid step: %s. Steps must have at least one of: command, commands, trigger, or group with nested steps.", context)
+	log.Warnf("Skipping invalid step: %s. Steps must have at least one of: command, commands, trigger, plugins, or group with nested steps.", context)
 }
 
 func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {

--- a/plugin.go
+++ b/plugin.go
@@ -437,7 +437,7 @@ func processNestedSteps(steps []Step, env map[string]string) {
 
 		// Append top-level env to this step
 		for key, value := range env {
-			if steps[i].Command != nil || steps[i].Commands != nil {
+			if steps[i].Command != nil || steps[i].Commands != nil || len(steps[i].Plugins) > 0 {
 				if steps[i].Env == nil {
 					steps[i].Env = make(map[string]string)
 				}
@@ -467,7 +467,7 @@ func appendEnv(watch *WatchConfig, env map[string]string) {
 	watch.Step.Build.Env, _ = parseEnv(watch.Step.Build.RawEnv)
 
 	for key, value := range env {
-		if watch.Step.Command != nil || watch.Step.Commands != nil {
+		if watch.Step.Command != nil || watch.Step.Commands != nil || len(watch.Step.Plugins) > 0 {
 			if watch.Step.Env == nil {
 				watch.Step.Env = make(map[string]string)
 			}

--- a/plugin.go
+++ b/plugin.go
@@ -109,9 +109,9 @@ func (s Step) isValid() bool {
 	return s.hasAction()
 }
 
-// hasAction checks if a step has a command or trigger
+// hasAction checks if a step has a command, trigger, or plugins
 func (s Step) hasAction() bool {
-	return s.Command != nil || s.Commands != nil || s.Trigger != ""
+	return s.Command != nil || s.Commands != nil || s.Trigger != "" || len(s.Plugins) > 0
 }
 
 // hasValidNesting validates group step nesting

--- a/plugin.go
+++ b/plugin.go
@@ -482,7 +482,7 @@ func processNestedSteps(steps []Step, env map[string]string) {
 
 		// Append top-level env to this step
 		for key, value := range env {
-			if steps[i].Command != nil || steps[i].Commands != nil {
+			if steps[i].Command != nil || steps[i].Commands != nil || (len(steps[i].Plugins) > 0 && steps[i].Trigger == "") {
 				if steps[i].Env == nil {
 					steps[i].Env = make(map[string]string)
 				}
@@ -515,7 +515,7 @@ func appendEnv(watch *WatchConfig, env map[string]string) {
 		step.Build.Env, _ = parseEnv(step.Build.RawEnv)
 
 		for key, value := range env {
-			if step.Command != nil || step.Commands != nil {
+			if step.Command != nil || step.Commands != nil || (len(step.Plugins) > 0 && step.Trigger == "") {
 				if step.Env == nil {
 					step.Env = make(map[string]string)
 				}

--- a/plugin.go
+++ b/plugin.go
@@ -117,9 +117,9 @@ func (s Step) isValid() bool {
 	return s.hasAction()
 }
 
-// hasAction checks if a step has a command or trigger
+// hasAction checks if a step has a command, trigger, or plugins
 func (s Step) hasAction() bool {
-	return s.Command != nil || s.Commands != nil || s.Trigger != ""
+	return s.Command != nil || s.Commands != nil || s.Trigger != "" || len(s.Plugins) > 0
 }
 
 // hasValidNesting validates group step nesting

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1866,3 +1866,28 @@ func TestStepIsValid_EmptyPlugins(t *testing.T) {
 	}
 	assert.False(t, step.isValid())
 }
+
+func TestAppendEnv_PluginOnlyStep(t *testing.T) {
+	watch := WatchConfig{
+		Step: Step{
+			Label: "Build CDK image",
+			Plugins: []map[string]interface{}{
+				{"docker-compose#v5.12.1": map[string]interface{}{"build": "cdk"}},
+			},
+		},
+	}
+	appendEnv(&watch, map[string]string{"FOO": "bar"})
+	assert.Equal(t, map[string]string{"FOO": "bar"}, watch.Step.Env)
+}
+
+func TestAppendEnv_PluginOnlyStep_DoesNotPropagateToTriggerBuild(t *testing.T) {
+	watch := WatchConfig{
+		Step: Step{
+			Plugins: []map[string]interface{}{
+				{"docker-compose#v5.12.1": map[string]interface{}{"build": "cdk"}},
+			},
+		},
+	}
+	appendEnv(&watch, map[string]string{"FOO": "bar"})
+	assert.Nil(t, watch.Step.Build.Env)
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1843,3 +1843,26 @@ func TestStepIsValid_OnlyMetadata(t *testing.T) {
 	}
 	assert.False(t, step.isValid())
 }
+
+func TestStepIsValid_WithPluginsOnly(t *testing.T) {
+	step := Step{
+		Label: "Build CDK image",
+		Key:   "build_cdk_image",
+		Agents: Agent{"queue": "main"},
+		Plugins: []map[string]interface{}{
+			{"docker-compose#v5.12.1": map[string]interface{}{
+				"build": "cdk",
+				"push":  []string{"cdk:registry.example.com/cdk:latest"},
+			}},
+		},
+	}
+	assert.True(t, step.isValid())
+}
+
+func TestStepIsValid_EmptyPlugins(t *testing.T) {
+	step := Step{
+		Label:   "no plugins",
+		Plugins: []map[string]interface{}{},
+	}
+	assert.False(t, step.isValid())
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1941,3 +1941,26 @@ func TestStepMatrixRoundTripsToYAML(t *testing.T) {
 	assert.Contains(t, yamlStr, "- linux")
 	assert.Contains(t, yamlStr, "- windows")
 }
+
+func TestStepIsValid_WithPluginsOnly(t *testing.T) {
+	step := Step{
+		Label:  "Build CDK image",
+		Key:    "build_cdk_image",
+		Agents: Agent{"queue": "main"},
+		Plugins: []map[string]interface{}{
+			{"docker-compose#v5.12.1": map[string]interface{}{
+				"build": "cdk",
+				"push":  []string{"cdk:registry.example.com/cdk:latest"},
+			}},
+		},
+	}
+	assert.True(t, step.isValid())
+}
+
+func TestStepIsValid_EmptyPlugins(t *testing.T) {
+	step := Step{
+		Label:   "no plugins",
+		Plugins: []map[string]interface{}{},
+	}
+	assert.False(t, step.isValid())
+}

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1964,3 +1964,58 @@ func TestStepIsValid_EmptyPlugins(t *testing.T) {
 	}
 	assert.False(t, step.isValid())
 }
+
+func TestAppendEnv_PluginOnlyStep(t *testing.T) {
+	watch := WatchConfig{
+		Steps: []Step{{
+			Label: "Build CDK image",
+			Plugins: []map[string]interface{}{
+				{"docker-compose#v5.12.1": map[string]interface{}{"build": "cdk"}},
+			},
+		}},
+	}
+	appendEnv(&watch, map[string]string{"FOO": "bar"})
+	assert.Equal(t, map[string]string{"FOO": "bar"}, watch.Steps[0].Env)
+}
+
+func TestAppendEnv_PluginOnlyStep_DoesNotPropagateToTriggerBuild(t *testing.T) {
+	watch := WatchConfig{
+		Steps: []Step{{
+			Plugins: []map[string]interface{}{
+				{"docker-compose#v5.12.1": map[string]interface{}{"build": "cdk"}},
+			},
+		}},
+	}
+	appendEnv(&watch, map[string]string{"FOO": "bar"})
+	assert.Nil(t, watch.Steps[0].Build.Env)
+}
+
+func TestAppendEnv_PluginOnlyNestedStep(t *testing.T) {
+	watch := WatchConfig{
+		Steps: []Step{{
+			Group: "Build images",
+			Steps: []Step{{
+				Plugins: []map[string]interface{}{
+					{"docker-compose#v5.12.1": map[string]interface{}{"build": "cdk"}},
+				},
+			}},
+		}},
+	}
+	appendEnv(&watch, map[string]string{"FOO": "bar"})
+	assert.Equal(t, map[string]string{"FOO": "bar"}, watch.Steps[0].Steps[0].Env)
+	assert.True(t, watch.Steps[0].isValid())
+}
+
+func TestAppendEnv_TriggerWithPluginsPreservesTriggerEnv(t *testing.T) {
+	watch := WatchConfig{
+		Steps: []Step{{
+			Trigger: "downstream-pipeline",
+			Plugins: []map[string]interface{}{
+				{"some-plugin#v1.0.0": map[string]interface{}{}},
+			},
+		}},
+	}
+	appendEnv(&watch, map[string]string{"FOO": "bar"})
+	assert.Nil(t, watch.Steps[0].Env)
+	assert.Equal(t, map[string]string{"FOO": "bar"}, watch.Steps[0].Build.Env)
+}


### PR DESCRIPTION
## Problem

Buildkite supports plugin-only steps — steps where the plugin itself provides execution (e.g. docker-compose#vX, docker#vX). These steps have no command:, commands:, or trigger: field.

Since v1.9.0 (#158), hasAction() only checks those three fields, so plugin-only steps are silently dropped with a Skipping invalid step warning and never appear in the generated pipeline.