### PR TITLE
feat: add regex support to path matching via regex_paths flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ steps:
       - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
-            - path: "src/(?!pulumi|ci-generators|desktop|mobile|test)(?!.*\\.test\\.)(?!.*\\.snap$)(?!.*/__test__/)(?!.*/__mocks__/)(?!.*/__snapshots__/).*\\.[tj]sx?"
+            - path: "^src/(?!pulumi|ci-generators|desktop|mobile|test)(?!.*\\.test\\.)(?!.*\\.snap$)(?!.*/__test__/)(?!.*/__mocks__/)(?!.*/__snapshots__/).*\\.[tj]sx?"
               regex_paths: true
               config:
                 trigger: "frontend-pipeline"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ When `regex_paths: true` is set, except paths are also treated as regular expres
 
 Set to `true` to treat `path`, `skip_path`, and `except_path` as regular expressions instead of globs. Uses [regexp2](https://github.com/dlclark/regexp2) which supports full PCRE syntax including lookaheads and lookbehinds.
 
+Regex matching is unanchored: a pattern matches if it occurs anywhere in the file path, not only at the start. For example, `path: "src/.*"` matches `vendor/src/main.go` as well as `src/main.go`. Anchor with `^` (and `$` where needed) to match the full path, as in the example above.
+
 This is useful when the paths you want to match would require many glob patterns to express. For example, to match all TypeScript/JavaScript source files under `src/` while excluding test files, snapshots, and specific directories:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ For example, in the following configuration:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "**/*"
@@ -152,7 +152,7 @@ The plugin preserves `plugins:` blocks when specified in command step configurat
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           watch:
             - path: services/api/
               config:
@@ -177,7 +177,7 @@ When changes are detected in the watched paths, the plugin generates steps that 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           watch:
             - path: app/
               config:
@@ -208,7 +208,7 @@ steps:
 steps:
   - label: "Triggering pipelines with plugin"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           watch:
             - path: test/.buildkite/
               config: # Required [trigger step configuration]
@@ -237,7 +237,7 @@ The plugin supports conditional execution of pipeline steps using the `if` key, 
 steps:
   - label: "Triggering pipelines with plugin"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: git diff --name-only HEAD~1
           watch:
             - path: services/api
@@ -305,7 +305,7 @@ git diff --name-only "$LATEST_TAG"
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -332,7 +332,7 @@ A default `config` to run if no paths are matched, the `config` key is not requi
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -354,7 +354,7 @@ The object values provided in this configuration will be appended to `env` prope
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "foo-service/"
@@ -380,7 +380,7 @@ The map format provides clean, readable syntax:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           env:
             NODE_ENV: production
             API_URL: https://api.example.com
@@ -415,7 +415,7 @@ The array format uses key=value syntax:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           env:
             - NODE_ENV=production
             - API_URL=https://api.example.com
@@ -455,7 +455,7 @@ Add `log_level` property to set the log level. Supported log levels are `debug` 
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           log_level: "debug" # defaults to "info"
           watch:
@@ -479,7 +479,7 @@ This option is useful for:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           download: false
           diff: "git diff --name-only HEAD~1"
           watch:
@@ -509,7 +509,7 @@ To enable checksum verification:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           verify_checksum: true  # Recommended for enhanced security
           diff: "git diff --name-only HEAD~1"
           watch:
@@ -544,7 +544,7 @@ Add `key` to set the step or group key.
 steps:
   - label: "Setting Key"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "bar-service/"
@@ -563,7 +563,7 @@ Add `secrets` to inject [Buildkite Secrets](https://buildkite.com/docs/pipelines
 steps:
   - label: "Deploy with secrets"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "service/"
@@ -580,7 +580,7 @@ steps:
 steps:
   - label: "Deploy with secrets"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "service/"
@@ -597,7 +597,7 @@ Secrets also work within grouped steps:
 steps:
   - label: "Deploy services"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only HEAD~1"
           watch:
             - path: "services/"
@@ -620,7 +620,7 @@ steps:
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           diff: "git diff --name-only $(head -n 1 last_successful_build)"
           interpolation: false
           env:
@@ -691,7 +691,7 @@ This is the filesystem folder where the Go binary will be kept.
 steps:
   - label: "Triggering pipelines"
     plugins:
-      - monorepo-diff#v1.9.1:
+      - monorepo-diff#v1.10.0:
           binary_folder: "/var/buildkite-agent"
           watch:
             - path: "bar-service/"

--- a/README.md
+++ b/README.md
@@ -27,17 +27,44 @@ It defines a list of paths or path to monitor for changes in the monorepo. It ch
 
 A path or a list of paths to be watched, This part specifies which directory should be monitored. It can also be a glob pattern. For example specify `path: "**/*.md"` to match all markdown files. A list of paths can be provided to trigger the desired pipeline or run command or even do a pipeline upload.
 
+When `regex_paths: true` is set on the watch block, paths are treated as regular expressions instead of globs.
+
 ### `skip_path`
 
 A path or a list of paths to be ignored, which can be an exact path, or a glob.
 
 This is intended to be used in conjunction with `path`, and allows omitting specific paths from being matched.
 
+When `regex_paths: true` is set, skip paths are also treated as regular expressions.
+
 ### `except_path`
 
 A path or a list of paths to prevent the paths listed to be matched, which can be an exact path, or a glob.
 
 This is intended to be used in conjunction with `path`, and allows for creating exclusive matches with simpler rules when several files are modified in the same execution.
+
+When `regex_paths: true` is set, except paths are also treated as regular expressions.
+
+### `regex_paths`
+
+Set to `true` to treat `path`, `skip_path`, and `except_path` as regular expressions instead of globs. Uses [regexp2](https://github.com/dlclark/regexp2) which supports full PCRE syntax including lookaheads and lookbehinds.
+
+This is useful when the paths you want to match would require many glob patterns to express. For example, to match all TypeScript/JavaScript source files under `src/` while excluding test files, snapshots, and specific directories:
+
+```yaml
+steps:
+  - label: "Triggering pipelines"
+    plugins:
+      - monorepo-diff#v1.10.0:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "src/(?!pulumi|ci-generators|desktop|mobile|test)(?!.*\\.test\\.)(?!.*\\.snap$)(?!.*/__test__/)(?!.*/__mocks__/)(?!.*/__snapshots__/).*\\.[tj]sx?"
+              regex_paths: true
+              config:
+                trigger: "frontend-pipeline"
+```
+
+> **Note:** When `regex_paths: true`, all paths in that watch block must be valid regular expressions. Glob syntax (e.g. `**`) is not supported in regex mode.
 
 For example, in the following configuration:
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.26.3
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/buildkite/bintest/v3 v3.3.0
+	github.com/dlclark/regexp2 v1.12.0
 	github.com/google/go-cmp v0.7.0
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
@@ -15,7 +16,6 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/buildkite/bintest/v3 v3.3.0 h1:RTWcSaJRlOT6t/K311ejPf+0J3LE/QEODzVG3v
 github.com/buildkite/bintest/v3 v3.3.0/go.mod h1:btqpTsVODiJcb0NMdkkmtMQ6xoFc2W/nY5yy+3I0zcs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=

--- a/pipeline.go
+++ b/pipeline.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/dlclark/regexp2"
@@ -261,8 +262,12 @@ func matchPath(p string, f string, useRegex bool) (bool, error) {
 	if useRegex {
 		re, err := regexp2.Compile(p, 0)
 		if err != nil {
-			return false, fmt.Errorf("regex path matching failed: %v", err)
+			if strings.Contains(p, "*") {
+				return false, fmt.Errorf("regex path matching failed for %q: %v (glob syntax is not supported when regex_paths is true)", p, err)
+			}
+			return false, fmt.Errorf("regex path matching failed for %q: %v", p, err)
 		}
+		re.MatchTimeout = 5 * time.Second
 		match, err := re.MatchString(f)
 		if err != nil {
 			return false, fmt.Errorf("regex path matching failed: %v", err)

--- a/pipeline.go
+++ b/pipeline.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/dlclark/regexp2"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )
@@ -194,7 +195,7 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 			}
 
 			for _, f := range files {
-				exceptMatch, errExcept := matchPath(ex, f)
+				exceptMatch, errExcept := matchPath(ex, f, w.RegexPaths)
 				if errExcept != nil {
 					return nil, errExcept
 				}
@@ -212,11 +213,11 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 
 		for _, p := range w.Paths {
 			for _, f := range files {
-				match, err := matchPath(p, f)
+				match, err := matchPath(p, f, w.RegexPaths)
 
 				skip := false
 				for _, sp := range w.SkipPaths {
-					skipMatch, errSkip := matchPath(sp, f)
+					skipMatch, errSkip := matchPath(sp, f, w.RegexPaths)
 
 					if errSkip != nil {
 						return nil, errSkip
@@ -255,7 +256,19 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 }
 
 // matchPath checks if the file f matches the path p.
-func matchPath(p string, f string) (bool, error) {
+// If useRegex is true, p is treated as a regexp2 regular expression.
+func matchPath(p string, f string, useRegex bool) (bool, error) {
+	if useRegex {
+		re, err := regexp2.Compile(p, 0)
+		if err != nil {
+			return false, fmt.Errorf("regex path matching failed: %v", err)
+		}
+		match, err := re.MatchString(f)
+		if err != nil {
+			return false, fmt.Errorf("regex path matching failed: %v", err)
+		}
+		return match, nil
+	}
 	// If the path contains a glob, the `doublestar.Match`
 	// method is used to determine the match,
 	// otherwise `strings.HasPrefix` is used.

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -558,6 +558,180 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 	}
 }
 
+func TestRegexPaths(t *testing.T) {
+	testCases := map[string]struct {
+		ChangedFiles []string
+		WatchConfigs []WatchConfig
+		Expected     []Step
+		ExpectError  bool
+	}{
+		"matches path using regex with lookahead": {
+			ChangedFiles: []string{
+				"src/components/Button.tsx",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/(?!__tests__/).*\.[tj]sx?`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-1"},
+			},
+		},
+		"does not match path excluded by negative lookahead": {
+			ChangedFiles: []string{
+				"src/__tests__/Button.test.tsx",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/(?!__tests__/).*\.[tj]sx?`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{},
+		},
+		"matches customer example pattern": {
+			ChangedFiles: []string{
+				"src/components/Button.tsx",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/(?!pulumi|ci-generators|desktop|mobile|test)(?!.*\.test\.)(?!.*\.snap$)(?!.*/__test__/)(?!.*/__mocks__/)(?!.*/__snapshots__/).*\.[tj]sx?`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-1"},
+			},
+		},
+		"skip_path regex excludes matched files": {
+			ChangedFiles: []string{
+				"src/components/Button.tsx",
+				"src/components/Button.test.tsx",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/.*\.[tj]sx?`},
+					SkipPaths:  []string{`.*\.test\.[tj]sx?`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-1"},
+			},
+		},
+		"except_path regex prevents step from triggering": {
+			ChangedFiles: []string{
+				"src/generated/schema.ts",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:       []string{`src/.*`},
+					ExceptPaths: []string{`src/generated/.*`},
+					RegexPaths:  true,
+					Step:        Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{},
+		},
+		"invalid regex returns error": {
+			ChangedFiles: []string{
+				"src/components/Button.tsx",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/[invalid`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected:    []Step{},
+			ExpectError: true,
+		},
+		"regex_paths false uses existing glob behaviour": {
+			ChangedFiles: []string{
+				"src/components/Button.tsx",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/**/*.tsx`},
+					RegexPaths: false,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "service-1"},
+			},
+		},
+		"regex and non-regex watch blocks work independently": {
+			ChangedFiles: []string{
+				"src/components/Button.tsx",
+				"services/api/main.go",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/(?!__tests__/).*\.tsx`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "frontend"},
+				},
+				{
+					Paths: []string{"services/api/"},
+					Step:  Step{Trigger: "backend"},
+				},
+			},
+			Expected: []Step{
+				{Trigger: "frontend"},
+				{Trigger: "backend"},
+			},
+		},
+		"invalid regex in skip_path returns error": {
+			ChangedFiles: []string{
+				"src/main.go",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/.*`},
+					SkipPaths:  []string{`src/[invalid`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected:    []Step{},
+			ExpectError: true,
+		},
+		"regex does not match unrelated file": {
+			ChangedFiles: []string{
+				"docs/readme.md",
+			},
+			WatchConfigs: []WatchConfig{
+				{
+					Paths:      []string{`src/.*\.go`},
+					RegexPaths: true,
+					Step:       Step{Trigger: "service-1"},
+				},
+			},
+			Expected: []Step{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			steps, err := stepsToTrigger(tc.ChangedFiles, tc.WatchConfigs)
+			if tc.ExpectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.Expected, steps)
+			}
+		})
+	}
+}
+
 func TestGeneratePipeline(t *testing.T) {
 	steps := []Step{
 		{

--- a/plugin.go
+++ b/plugin.go
@@ -43,6 +43,7 @@ type WatchConfig struct {
 	RawExceptPath interface{} `json:"except_path"`
 	SkipPaths     []string
 	ExceptPaths   []string
+	RegexPaths    bool        `json:"regex_paths"`
 }
 
 type Group struct {

--- a/plugin.go
+++ b/plugin.go
@@ -43,7 +43,7 @@ type WatchConfig struct {
 	RawExceptPath interface{} `json:"except_path"`
 	SkipPaths     []string
 	ExceptPaths   []string
-	RegexPaths    bool        `json:"regex_paths"`
+	RegexPaths    bool `json:"regex_paths"`
 }
 
 type Group struct {

--- a/plugin.yml
+++ b/plugin.yml
@@ -48,6 +48,11 @@ configuration:
         path:
           type: [string, array]
           minimum: 1
+        regex_paths:
+          type: boolean
+          description: >
+            When true, path, skip_path, and except_path are treated as regexp2 regular expressions
+            instead of globs. Supports full PCRE syntax including lookaheads.
         config:
           type: object
           properties:

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1843,3 +1843,19 @@ func TestStepIsValid_OnlyMetadata(t *testing.T) {
 	}
 	assert.False(t, step.isValid())
 }
+
+func TestPluginParsesRegexPaths(t *testing.T) {
+	param := `[{
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
+			"watch": [{
+				"path": "src/.*\\.go",
+				"regex_paths": true,
+				"config": { "trigger": "service-1" }
+			}]
+		}
+	}]`
+
+	got, err := initializePlugin(param)
+	assert.NoError(t, err)
+	assert.True(t, got.Watch[0].RegexPaths)
+}


### PR DESCRIPTION
 Add a new  boolean option to watch blocks in the plugin config. When set to true, all path matching for ,and  is handled by regexp2 instead of the existing glob/prefix matching.

When regex_paths is false (the default), existing glob and prefix matching behaviour is completely unchanged ,so no impact on existing users.

  Changes:
  - plugin.go: added RegexPaths field to WatchConfig struct
  - pipeline.go: updated matchPath to accept a useRegex flag and route through regexp2 when set; updated all 3 call sites in stepsToTrigger
  - pipeline_test.go: added TestRegexPaths with 10 test cases covering lookaheads, skip_path, except_path, invalid regex, mixed blocks, and regression check for existing glob behaviour
  - plugin.yml: documented regex_paths as a boolean property
  - README.md: added regex_paths section with customer example pattern

