### PR TITLE
feat: propagate group step attributes to generated pipeline YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,26 @@ In the example above,
 - The `deploy-api` trigger will only run on the main branch or branches matching `release/*`.
 - The `web deployment` command will run only if the build has a tag.
 
+`if` also works at the group step level, controlling whether the entire group runs:
+
+```yaml
+steps:
+  - label: "Triggering pipelines with plugin"
+    plugins:
+      - monorepo-diff#v1.10.0:
+          diff: git diff --name-only HEAD~1
+          watch:
+            - path: services/
+              config:
+                group: "Deploy Services"
+                if: build.branch == 'main'
+                steps:
+                  - command: deploy-uat.sh
+                    label: Deploy UAT
+                  - command: deploy-prod.sh
+                    label: Deploy Prod
+```
+
 #### `diff` (optional)
 
 This will run the script provided to determine the folder changes.
@@ -553,6 +573,47 @@ steps:
               config:
                 key: echo-step
                 command: "echo deploy-bar"
+```
+
+### `depends_on` (optional)
+
+Add `depends_on` to declare step or group dependencies. Accepts a single key string or a list of keys.
+
+```yaml
+steps:
+  - label: "Deploy"
+    plugins:
+      - monorepo-diff#v1.10.0:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "bar-service/"
+              config:
+                group: "Deploy Bar"
+                depends_on: "build-bar"
+                steps:
+                  - command: "echo deploy-bar"
+                    label: "Deploy Bar"
+```
+
+### `allow_dependency_failure` (optional)
+
+Set `allow_dependency_failure: true` to allow a step or group to run even if the steps it `depends_on` have failed.
+
+```yaml
+steps:
+  - label: "Deploy"
+    plugins:
+      - monorepo-diff#v1.10.0:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "bar-service/"
+              config:
+                group: "Deploy Bar"
+                depends_on: "build-bar"
+                allow_dependency_failure: true
+                steps:
+                  - command: "echo deploy-bar"
+                    label: "Deploy Bar"
 ```
 
 ### `secrets` (optional)

--- a/README.md
+++ b/README.md
@@ -616,6 +616,28 @@ steps:
                     label: "Deploy Bar"
 ```
 
+### `notify` (optional)
+
+Add `notify` to send notifications when a group step completes. Accepts the same notification types as Buildkite step-level notify.
+
+```yaml
+steps:
+  - label: "Deploy"
+    plugins:
+      - monorepo-diff#v1.10.0:
+          diff: "git diff --name-only HEAD~1"
+          watch:
+            - path: "bar-service/"
+              config:
+                group: "Deploy Bar"
+                notify:
+                  - slack: "#deployments"
+                    if: "build.state == 'passed'"
+                steps:
+                  - command: "echo deploy-bar"
+                    label: "Deploy Bar"
+```
+
 ### `secrets` (optional)
 
 Add `secrets` to inject [Buildkite Secrets](https://buildkite.com/docs/pipelines/security/secrets/buildkite-secrets) into your command steps. Secrets can be specified in two formats:

--- a/pipeline.go
+++ b/pipeline.go
@@ -34,13 +34,31 @@ func (s Step) MarshalYAML() (interface{}, error) {
 
 	label := s.Group
 	key := s.Key
+	dependsOn := s.DependsOn
+	condition := s.Condition
+	notify := s.Notify
+	allowDepFail := s.AllowDependencyFailure
+
 	s.Group = ""
 	s.Key = ""
+	s.DependsOn = nil
+	s.Condition = ""
+	s.Notify = nil
+	s.AllowDependencyFailure = false
+
 	stps := []Step{s}
 	if s.Steps != nil {
 		stps = s.Steps
 	}
-	return Group{Label: label, Key: key, Steps: stps}, nil
+	return Group{
+		Label:                  label,
+		Key:                    key,
+		Steps:                  stps,
+		DependsOn:              dependsOn,
+		Condition:              condition,
+		Notify:                 notify,
+		AllowDependencyFailure: allowDepFail,
+	}, nil
 }
 
 func (n PluginNotify) MarshalYAML() (interface{}, error) {

--- a/pipeline.go
+++ b/pipeline.go
@@ -37,7 +37,7 @@ func (s Step) MarshalYAML() (interface{}, error) {
 	dependsOn := s.DependsOn
 	condition := s.Condition
 	notify := s.Notify
-	allowDepFail := s.AllowDependencyFailure
+	allowDependencyFailure := s.AllowDependencyFailure
 
 	s.Group = ""
 	s.Key = ""
@@ -57,7 +57,7 @@ func (s Step) MarshalYAML() (interface{}, error) {
 		DependsOn:              dependsOn,
 		Condition:              condition,
 		Notify:                 notify,
-		AllowDependencyFailure: allowDepFail,
+		AllowDependencyFailure: allowDependencyFailure,
 	}, nil
 }
 

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1201,8 +1201,6 @@ func TestGeneratePipelineWithKeyInGroup(t *testing.T) {
 	validatePipelineWithAgent(t, tmp.Name())
 }
 
-// SUP-6862: group step attributes silently dropped or missing
-
 func TestGeneratePipelineWithDependsOnInGroup(t *testing.T) {
 	steps := []Step{{
 		Group:     "Deploy Group",
@@ -1229,7 +1227,7 @@ func TestGeneratePipelineWithDependsOnInGroup(t *testing.T) {
 func TestGeneratePipelineWithConditionInGroup(t *testing.T) {
 	steps := []Step{{
 		Group:     "Conditional Group",
-		Condition: "build.branch == \"main\"",
+		Condition: "build.branch == 'main'",
 		Steps: []Step{{
 			Label:   "Run",
 			Command: "echo run",
@@ -1246,7 +1244,7 @@ func TestGeneratePipelineWithConditionInGroup(t *testing.T) {
 	output := string(content)
 
 	assert.Contains(t, output, "group: Conditional Group")
-	assert.Contains(t, output, "if:", "if condition should be propagated to group step")
+	assert.Contains(t, output, "if: build.branch == 'main'", "if condition value should be propagated to group step")
 }
 
 func TestGeneratePipelineWithNotifyOnGroup(t *testing.T) {
@@ -1297,6 +1295,55 @@ func TestGeneratePipelineWithAllowDependencyFailureInGroup(t *testing.T) {
 
 	assert.Contains(t, output, "group: Flaky Group")
 	assert.Contains(t, output, "allow_dependency_failure: true", "allow_dependency_failure should be propagated to group step")
+}
+
+func TestGeneratePipelineWithDependsOnListInGroup(t *testing.T) {
+	steps := []Step{{
+		Group:     "Multi-dep Group",
+		DependsOn: []string{"build-a", "build-b"},
+		Steps: []Step{{
+			Label:   "Deploy",
+			Command: "echo deploy",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.Contains(t, output, "group: Multi-dep Group")
+	assert.Contains(t, output, "build-a", "list-valued depends_on should be propagated to group step")
+	assert.Contains(t, output, "build-b", "list-valued depends_on should be propagated to group step")
+}
+
+func TestGeneratePipelineAllowDependencyFailureFalseOmitted(t *testing.T) {
+	// allow_dependency_failure uses omitempty — an explicit false must not appear in output,
+	// matching the same behaviour as other bool fields like async.
+	steps := []Step{{
+		Group:                  "Normal Group",
+		DependsOn:              "build",
+		AllowDependencyFailure: false,
+		Steps: []Step{{
+			Label:   "Deploy",
+			Command: "echo deploy",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.NotContains(t, output, "allow_dependency_failure", "allow_dependency_failure: false should be omitted from output")
 }
 
 func TestGeneratePipelineGroupAttributesNotDuplicatedOnNestedStep(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1317,8 +1317,8 @@ func TestGeneratePipelineWithDependsOnListInGroup(t *testing.T) {
 	output := string(content)
 
 	assert.Contains(t, output, "group: Multi-dep Group")
-	assert.Contains(t, output, "build-a", "list-valued depends_on should be propagated to group step")
-	assert.Contains(t, output, "build-b", "list-valued depends_on should be propagated to group step")
+	assert.Contains(t, output, "- build-a", "list-valued depends_on should be propagated to group step")
+	assert.Contains(t, output, "- build-b", "list-valued depends_on should be propagated to group step")
 }
 
 func TestGeneratePipelineAllowDependencyFailureFalseOmitted(t *testing.T) {
@@ -1353,7 +1353,7 @@ func TestGeneratePipelineGroupAttributesNotDuplicatedOnNestedStep(t *testing.T) 
 		Group:                  "Deploy Group",
 		Command:                "echo deploy",
 		DependsOn:              "build",
-		Condition:              "build.branch == \"main\"",
+		Condition:              "build.branch == 'main'",
 		AllowDependencyFailure: true,
 		Notify: []StepNotify{{
 			Slack: "#deployments",

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/buildkite/bintest/v3"
@@ -1198,6 +1199,134 @@ func TestGeneratePipelineWithKeyInGroup(t *testing.T) {
 	assert.Contains(t, output, "label: Run Tests")
 
 	validatePipelineWithAgent(t, tmp.Name())
+}
+
+// SUP-6862: group step attributes silently dropped or missing
+
+func TestGeneratePipelineWithDependsOnInGroup(t *testing.T) {
+	steps := []Step{{
+		Group:     "Deploy Group",
+		DependsOn: "build",
+		Steps: []Step{{
+			Label:   "Deploy",
+			Command: "echo deploy",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.Contains(t, output, "group: Deploy Group")
+	assert.Contains(t, output, "depends_on: build", "depends_on should be propagated to group step")
+}
+
+func TestGeneratePipelineWithConditionInGroup(t *testing.T) {
+	steps := []Step{{
+		Group:     "Conditional Group",
+		Condition: "build.branch == \"main\"",
+		Steps: []Step{{
+			Label:   "Run",
+			Command: "echo run",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.Contains(t, output, "group: Conditional Group")
+	assert.Contains(t, output, "if:", "if condition should be propagated to group step")
+}
+
+func TestGeneratePipelineWithNotifyOnGroup(t *testing.T) {
+	steps := []Step{{
+		Group: "Notify Group",
+		Notify: []StepNotify{{
+			Slack: "#deployments",
+		}},
+		Steps: []Step{{
+			Label:   "Deploy",
+			Command: "echo deploy",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.Contains(t, output, "group: Notify Group")
+	assert.Contains(t, output, "notify:", "notify should be propagated to group step")
+	assert.Contains(t, output, "slack: '#deployments'", "slack notify value should appear in group step")
+}
+
+func TestGeneratePipelineWithAllowDependencyFailureInGroup(t *testing.T) {
+	steps := []Step{{
+		Group:                  "Flaky Group",
+		DependsOn:              "setup",
+		AllowDependencyFailure: true,
+		Steps: []Step{{
+			Label:   "Flaky Test",
+			Command: "echo test",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.Contains(t, output, "group: Flaky Group")
+	assert.Contains(t, output, "allow_dependency_failure: true", "allow_dependency_failure should be propagated to group step")
+}
+
+func TestGeneratePipelineGroupAttributesNotDuplicatedOnNestedStep(t *testing.T) {
+	// When Steps is nil, the step itself becomes the single nested step.
+	// Group-level attributes must not also appear on that nested step.
+	steps := []Step{{
+		Group:                  "Deploy Group",
+		Command:                "echo deploy",
+		DependsOn:              "build",
+		Condition:              "build.branch == \"main\"",
+		AllowDependencyFailure: true,
+		Notify: []StepNotify{{
+			Slack: "#deployments",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	// Group-level attributes must appear exactly once
+	assert.Equal(t, 1, strings.Count(output, "depends_on:"), "depends_on should appear once (on the group, not also on the nested step)")
+	assert.Equal(t, 1, strings.Count(output, "if:"), "if should appear once (on the group, not also on the nested step)")
+	assert.Equal(t, 1, strings.Count(output, "notify:"), "notify should appear once (on the group, not also on the nested step)")
+	assert.Equal(t, 1, strings.Count(output, "allow_dependency_failure:"), "allow_dependency_failure should appear once (on the group, not also on the nested step)")
 }
 
 func TestGeneratePipelineWithPlugins(t *testing.T) {

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -1222,6 +1222,7 @@ func TestGeneratePipelineWithDependsOnInGroup(t *testing.T) {
 
 	assert.Contains(t, output, "group: Deploy Group")
 	assert.Contains(t, output, "depends_on: build", "depends_on should be propagated to group step")
+	validatePipelineWithAgent(t, tmp.Name())
 }
 
 func TestGeneratePipelineWithConditionInGroup(t *testing.T) {
@@ -1245,6 +1246,7 @@ func TestGeneratePipelineWithConditionInGroup(t *testing.T) {
 
 	assert.Contains(t, output, "group: Conditional Group")
 	assert.Contains(t, output, "if: build.branch == 'main'", "if condition value should be propagated to group step")
+	validatePipelineWithAgent(t, tmp.Name())
 }
 
 func TestGeneratePipelineWithNotifyOnGroup(t *testing.T) {
@@ -1271,6 +1273,7 @@ func TestGeneratePipelineWithNotifyOnGroup(t *testing.T) {
 	assert.Contains(t, output, "group: Notify Group")
 	assert.Contains(t, output, "notify:", "notify should be propagated to group step")
 	assert.Contains(t, output, "slack: '#deployments'", "slack notify value should appear in group step")
+	validatePipelineWithAgent(t, tmp.Name())
 }
 
 func TestGeneratePipelineWithAllowDependencyFailureInGroup(t *testing.T) {
@@ -1295,6 +1298,7 @@ func TestGeneratePipelineWithAllowDependencyFailureInGroup(t *testing.T) {
 
 	assert.Contains(t, output, "group: Flaky Group")
 	assert.Contains(t, output, "allow_dependency_failure: true", "allow_dependency_failure should be propagated to group step")
+	validatePipelineWithAgent(t, tmp.Name())
 }
 
 func TestGeneratePipelineWithDependsOnListInGroup(t *testing.T) {
@@ -1319,6 +1323,32 @@ func TestGeneratePipelineWithDependsOnListInGroup(t *testing.T) {
 	assert.Contains(t, output, "group: Multi-dep Group")
 	assert.Contains(t, output, "- build-a", "list-valued depends_on should be propagated to group step")
 	assert.Contains(t, output, "- build-b", "list-valued depends_on should be propagated to group step")
+	validatePipelineWithAgent(t, tmp.Name())
+}
+
+func TestGeneratePipelineWithDependsOnGroupAndNestedStep(t *testing.T) {
+	steps := []Step{{
+		Group:     "Deploy Group",
+		DependsOn: "setup",
+		Steps: []Step{{
+			Label:     "Deploy",
+			Command:   "echo deploy",
+			DependsOn: "build",
+		}},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.Contains(t, output, "group: Deploy Group")
+	assert.Equal(t, 2, strings.Count(output, "depends_on:"), "depends_on should appear on both the group and the nested step independently")
+	validatePipelineWithAgent(t, tmp.Name())
 }
 
 func TestGeneratePipelineAllowDependencyFailureFalseOmitted(t *testing.T) {

--- a/plugin.go
+++ b/plugin.go
@@ -47,9 +47,13 @@ type WatchConfig struct {
 }
 
 type Group struct {
-	Label string `yaml:"group"`
-	Key   string `yaml:"key,omitempty"`
-	Steps []Step `yaml:"steps"`
+	Label                  string       `yaml:"group"`
+	Key                    string       `yaml:"key,omitempty"`
+	Steps                  []Step       `yaml:"steps"`
+	DependsOn              interface{}  `yaml:"depends_on,omitempty"`
+	Condition              string       `yaml:"if,omitempty"`
+	Notify                 []StepNotify `yaml:"notify,omitempty"`
+	AllowDependencyFailure bool         `yaml:"allow_dependency_failure,omitempty"`
 }
 
 // GithubStatusNotification is notification config for github_commit_status
@@ -78,28 +82,29 @@ type StepNotify struct {
 
 // Step is buildkite pipeline definition
 type Step struct {
-	Group         string                   `yaml:"group,omitempty"`
-	Trigger       string                   `yaml:"trigger,omitempty"`
-	Label         string                   `yaml:"label,omitempty"`
-	Branches      string                   `yaml:"branches,omitempty"`
-	Condition     string                   `json:"if,omitempty" yaml:"if,omitempty"`
-	Build         Build                    `yaml:"build,omitempty"`
-	Command       interface{}              `yaml:"command,omitempty"`
-	Commands      interface{}              `yaml:"commands,omitempty"`
-	Agents        Agent                    `yaml:"agents,omitempty"`
-	ArtifactPaths []string                 `json:"artifact_paths" yaml:"artifact_paths,omitempty"`
-	RawEnv        interface{}              `json:"env" yaml:",omitempty"`
-	Plugins       []map[string]interface{} `json:"plugins,omitempty" yaml:"plugins,omitempty"`
-	Env           map[string]string        `yaml:"env,omitempty"`
-	Async         bool                     `yaml:"async,omitempty"`
-	SoftFail      interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`
-	Retry         interface{}              `json:"retry,omitempty" yaml:"retry,omitempty"`
-	RawNotify     []map[string]interface{} `json:"notify" yaml:",omitempty"`
-	Notify        []StepNotify             `yaml:"notify,omitempty"`
-	DependsOn     interface{}              `json:"depends_on" yaml:"depends_on,omitempty"`
-	Key           string                   `yaml:"key,omitempty"`
-	Secrets       interface{}              `json:"secrets,omitempty" yaml:"secrets,omitempty"`
-	Steps         []Step                   `yaml:"steps,omitempty"`
+	Group                  string                   `yaml:"group,omitempty"`
+	Trigger                string                   `yaml:"trigger,omitempty"`
+	Label                  string                   `yaml:"label,omitempty"`
+	Branches               string                   `yaml:"branches,omitempty"`
+	Condition              string                   `json:"if,omitempty" yaml:"if,omitempty"`
+	Build                  Build                    `yaml:"build,omitempty"`
+	Command                interface{}              `yaml:"command,omitempty"`
+	Commands               interface{}              `yaml:"commands,omitempty"`
+	Agents                 Agent                    `yaml:"agents,omitempty"`
+	ArtifactPaths          []string                 `json:"artifact_paths" yaml:"artifact_paths,omitempty"`
+	RawEnv                 interface{}              `json:"env" yaml:",omitempty"`
+	Plugins                []map[string]interface{} `json:"plugins,omitempty" yaml:"plugins,omitempty"`
+	Env                    map[string]string        `yaml:"env,omitempty"`
+	Async                  bool                     `yaml:"async,omitempty"`
+	SoftFail               interface{}              `json:"soft_fail" yaml:"soft_fail,omitempty"`
+	Retry                  interface{}              `json:"retry,omitempty" yaml:"retry,omitempty"`
+	RawNotify              []map[string]interface{} `json:"notify" yaml:",omitempty"`
+	Notify                 []StepNotify             `yaml:"notify,omitempty"`
+	DependsOn              interface{}              `json:"depends_on" yaml:"depends_on,omitempty"`
+	Key                    string                   `yaml:"key,omitempty"`
+	Secrets                interface{}              `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	Steps                  []Step                   `yaml:"steps,omitempty"`
+	AllowDependencyFailure bool                     `json:"allow_dependency_failure,omitempty" yaml:"allow_dependency_failure,omitempty"`
 }
 
 // isValid checks if a step has required fields (command, trigger, or group with steps)

--- a/plugin.yml
+++ b/plugin.yml
@@ -56,8 +56,16 @@ configuration:
         config:
           type: object
           properties:
-            key: 
+            group:
               type: string
+            key:
+              type: string
+            depends_on:
+              type: [string, array]
+            if:
+              type: string
+            allow_dependency_failure:
+              type: boolean
             command:
               type: string
             trigger:


### PR DESCRIPTION
Fixes depends_on, if, notify, and allow_dependency_failure being silently dropped when a step with a group field was marshalled. Adds allow_dependency_failure to the Step struct (was missing entirely). Fields are cleared from the inner step to avoid duplication when the single-step group shorthand is used (no explicit steps array).