### PR TITLE
fix: support array format for agent selectors

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -180,6 +180,33 @@ func (step *Step) UnmarshalJSON(data []byte) error {
 // Agent is Buildkite agent definition
 type Agent map[string]string
 
+// UnmarshalJSON handles both map format ({"queue":"k8s"}) and array format (["queue=k8s"])
+func (a *Agent) UnmarshalJSON(data []byte) error {
+	// Try map format first
+	var m map[string]string
+	if err := json.Unmarshal(data, &m); err == nil {
+		*a = Agent(m)
+		return nil
+	}
+
+	// Try array format: ["key=value", ...]
+	var arr []string
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+
+	result := make(Agent, len(arr))
+	for _, entry := range arr {
+		k, v, ok := strings.Cut(entry, "=")
+		if !ok {
+			return fmt.Errorf("agent selector %q is not in key=value format", entry)
+		}
+		result[k] = v
+	}
+	*a = result
+	return nil
+}
+
 // Build is buildkite build definition
 type Build struct {
 	Message  string            `yaml:"message,omitempty"`

--- a/plugin.yml
+++ b/plugin.yml
@@ -107,7 +107,11 @@ configuration:
                     Environment variables. Array: ["KEY=value", "KEY"] or Map: {KEY: "value", KEY2: ~}
                     Array: KEY-only reads from OS. Map: use "KEY: ~" (null literal) to read from OS, "KEY: ''" for empty string.
             agents:
-              type: object
+              type: [array, object]
+              description: >
+                Agent selectors. Array: ["queue=k8s"] or Map: {queue: k8s}
+              items:
+                type: string
               properties:
                 queue:
                   type: string

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -1842,6 +1843,76 @@ func TestStepIsValid_OnlyMetadata(t *testing.T) {
 		},
 	}
 	assert.False(t, step.isValid())
+}
+
+func TestAgentUnmarshalJSON_MapFormat(t *testing.T) {
+	param := `[{
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
+			"watch": [{
+				"path": "src/foo",
+				"config": {
+					"command": "echo hi",
+					"agents": { "queue": "k8s", "os": "linux" }
+				}
+			}]
+		}
+	}]`
+
+	got, err := initializePlugin(param)
+	assert.NoError(t, err)
+	assert.Equal(t, Agent{"queue": "k8s", "os": "linux"}, got.Watch[0].Step.Agents)
+}
+
+func TestAgentUnmarshalJSON_ArrayFormat(t *testing.T) {
+	param := `[{
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
+			"watch": [{
+				"path": "src/foo",
+				"config": {
+					"command": "echo hi",
+					"agents": ["queue=k8s", "os=linux"]
+				}
+			}]
+		}
+	}]`
+
+	got, err := initializePlugin(param)
+	assert.NoError(t, err)
+	assert.Equal(t, Agent{"queue": "k8s", "os": "linux"}, got.Watch[0].Step.Agents)
+}
+
+func TestAgentUnmarshalJSON_ArrayFormat_NestedSteps(t *testing.T) {
+	param := `[{
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
+			"watch": [{
+				"path": "src/foo",
+				"config": {
+					"steps": [
+						{
+							"command": "echo first",
+							"agents": ["queue=k8s"]
+						},
+						{
+							"command": "echo second",
+							"agents": ["queue=k8s", "os=linux"]
+						}
+					]
+				}
+			}]
+		}
+	}]`
+
+	got, err := initializePlugin(param)
+	assert.NoError(t, err)
+	assert.Equal(t, Agent{"queue": "k8s"}, got.Watch[0].Step.Steps[0].Agents)
+	assert.Equal(t, Agent{"queue": "k8s", "os": "linux"}, got.Watch[0].Step.Steps[1].Agents)
+}
+
+func TestAgentUnmarshalJSON_ArrayInvalidFormat(t *testing.T) {
+	var a Agent
+	err := json.Unmarshal([]byte(`["noequals"]`), &a)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "key=value")
 }
 
 func TestPluginParsesRegexPaths(t *testing.T) {

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -1913,6 +1914,42 @@ func TestAgentUnmarshalJSON_ArrayInvalidFormat(t *testing.T) {
 	err := json.Unmarshal([]byte(`["noequals"]`), &a)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "key=value")
+}
+
+func TestAgentUnmarshalJSON_ArrayInvalidFormat_ThroughConfig(t *testing.T) {
+	param := `[{
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
+			"watch": [{
+				"path": "src/foo",
+				"config": { "command": "echo hi", "agents": ["noequals"] }
+			}]
+		}
+	}]`
+
+	_, err := initializePlugin(param)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "key=value")
+}
+
+func TestGeneratePipelineWithArrayFormatAgents(t *testing.T) {
+	steps := []Step{{
+		Label:   "Run Tests",
+		Command: "echo test",
+		Agents:  Agent{"queue": "k8s", "os": "linux"},
+	}}
+
+	tmp, hasPipeline, err := generatePipeline(steps, Plugin{})
+	assert.NoError(t, err)
+	assert.True(t, hasPipeline)
+	defer os.Remove(tmp.Name())
+
+	content, err := os.ReadFile(tmp.Name())
+	assert.NoError(t, err)
+	output := string(content)
+
+	assert.Contains(t, output, "agents:")
+	assert.Contains(t, output, "queue: k8s")
+	validatePipelineWithAgent(t, tmp.Name())
 }
 
 func TestPluginParsesRegexPaths(t *testing.T) {


### PR DESCRIPTION
## Summary

  - `Agent` (`map[string]string`) only accepted the YAML/JSON map form for
    agent selectors (`queue: k8s`). Buildkite also accepts an array form
    (`- queue=k8s`), causing a fatal unmarshal error when that form was used
    inside `config.steps[*].agents` in a watch config.
  - Added `UnmarshalJSON` on `Agent` that tries map format first, then
    falls back to parsing `["key=value"]` array entries via `strings.Cut`.
  - Added tests covering: map format, single-step array format, nested
    `config.steps` array format, and invalid array entries (missing `=`).

  ## Test plan

  - [ ] `go test ./... -run TestAgent` — all 4 new tests pass
  - [ ] `go test ./...` — full suite green
  - [ ] Manual: pipeline using `agents: [queue=k8s]` inside monorepo-diff
    watch config no longer exits with status 1