### PR TITLE
[SUP-5882] Chore: move release process to Buildkite pipeline

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -1,0 +1,71 @@
+agents:
+  queue: hosted
+
+steps:
+  - label: ":shell: Shellcheck"
+    key: shellcheck
+    plugins:
+      shellcheck#v1.4.0:
+        files:
+          - hooks/**
+          - lib/**
+          - commands/**
+
+  - label: ":sparkles: Lint"
+    key: lint
+    plugins:
+      plugin-linter#v3.3.0:
+        id: monorepo-diff
+
+  - label: ":golang: Test"
+    key: test
+    command: go test ./...
+    plugins:
+      - docker#v5.13.0:
+          image: "golang"
+          always-pull: true
+          workdir: /plugin
+          mount-buildkite-agent: true
+
+  - label: ":linux: Build"
+    key: build
+    command: make local
+    artifact_paths: monorepo-diff-buildkite-plugin
+    plugins:
+      - docker#v5.13.0:
+          image: "golang"
+          always-pull: true
+          workdir: /plugin
+
+  - wait: ~
+    depends_on:
+      - shellcheck
+      - lint
+      - test
+      - build
+
+  - label: ":rocket: :github: Release"
+    key: release
+    artifact_paths:
+      - dist/**/*
+    env:
+      AWS_REGION: us-east-1
+    plugins:
+      - aws-assume-role-with-web-identity#v1.6.0:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-monorail-plugin-monorepo-diff-release
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+      - aws-ssm#v1.1.0:
+          parameters:
+            GITHUB_TOKEN: /pipelines/buildkite/monorail-plugin-monorepo-diff-release/github-token
+      - docker#v5.13.0:
+          image: "goreleaser/goreleaser:v2"
+          always-pull: true
+          workdir: /plugin
+          environment:
+            - GITHUB_TOKEN
+          command:
+            - release
+            - --clean

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,14 @@ env:
   BUILDKITE_PLUGIN_MONOREPO_DIFF_BUILDKITE_PLUGIN_TEST_MODE: true
 
 steps:
+  - block: "Allow this build to run?"
+    key: allow_build
+
+  - wait: ~
+
   - label: ":shell: Shellcheck"
+    key: shellcheck
+    depends_on: allow_build
     plugins:
       shellcheck#v1.4.0:
         files:
@@ -11,11 +18,15 @@ steps:
           - commands/**
 
   - label: ":sparkles: Lint"
+    key: lint
+    depends_on: allow_build
     plugins:
       plugin-linter#v3.3.0:
         id: monorepo-diff
 
   - label: ":golang: Test"
+    key: test
+    depends_on: allow_build
     command: go test ./...
     plugins:
       - docker#v5.13.0:
@@ -25,6 +36,8 @@ steps:
           mount-buildkite-agent: true
 
   - label: ":linux: Build"
+    key: build
+    depends_on: allow_build
     command: make local
     artifact_paths: monorepo-diff-buildkite-plugin
     plugins:
@@ -35,6 +48,7 @@ steps:
 
   - label: "Security Scan"
     key: security_scan
+    depends_on: allow_build
     plugins:
       - secrets#v2.4.0:
           variables:
@@ -196,3 +210,49 @@ steps:
             - default:
                 config:
                   command: "echo hello-world"
+
+  - input: ":package: Create a release?"
+    key: release_unblock
+    prompt: "Select the release type"
+    branches:
+      - main
+    depends_on:
+      - shellcheck
+      - lint
+      - test
+      - build
+      - security_scan
+    allowed_teams:
+      - support
+      - deploy
+    blocked_state: passed
+    fields:
+      - key: release-type
+        select: "Release Type"
+        required: true
+        options:
+          - label: "Patch (v1.x.X)"
+            value: "patch"
+          - label: "Minor (v1.X.0)"
+            value: "minor"
+          - label: "Major (vX.0.0) - Manual only"
+            value: "major"
+
+  - label: ":rocket: Pushing a tag to release"
+    key: push_tag
+    command: ".buildkite/tag.sh"
+    branches:
+      - main
+    depends_on: release_unblock
+    env:
+      AWS_REGION: us-east-1
+    plugins:
+      - aws-assume-role-with-web-identity#v1.6.0:
+          role-arn: arn:aws:iam::445615400570:role/pipeline-buildkite-monorail-plugin-monorepo
+          session-tags:
+            - organization_slug
+            - organization_id
+            - pipeline_slug
+      - aws-ssm#v1.1.0:
+          parameters:
+            GITHUB_TOKEN: /pipelines/buildkite/monorail-plugin-monorepo/github-token

--- a/.buildkite/tag.sh
+++ b/.buildkite/tag.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# This script calculates the next semantic version and pushes a tag
+#
+set -euo pipefail
+
+RELEASE_TYPE="$(buildkite-agent meta-data get "release-type")"
+
+if [[ "${RELEASE_TYPE}" == "major" ]]; then
+  echo "🚨 Major releases require manual tagging to prevent accidents."
+  echo "Please run: git tag vX.0.0 && git push origin vX.0.0"
+  exit 1
+fi
+
+# Get latest tag matching v*.*.* pattern
+LATEST_TAG=$(git describe --tags --match "v[0-9]*" --abbrev=0 2>/dev/null) || {
+  echo "Error: No existing version tags found. Cannot calculate next version."
+  exit 1
+}
+
+echo "Latest tag: ${LATEST_TAG}"
+
+# Parse version (strip 'v' prefix and any pre-release suffix)
+VERSION="${LATEST_TAG#v}"
+IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION%%-*}"
+
+# Calculate new version
+case "${RELEASE_TYPE}" in
+  minor)
+    TAG="v${MAJOR}.$((MINOR + 1)).0"
+    ;;
+  patch)
+    TAG="v${MAJOR}.${MINOR}.$((PATCH + 1))"
+    ;;
+  *)
+    echo "Error: Unknown release type: ${RELEASE_TYPE}"
+    exit 1
+    ;;
+esac
+
+echo "New tag: ${TAG}"
+
+if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+  echo "Error: Tag ${TAG} already exists at origin"
+  exit 1
+fi
+
+echo "${TAG} does not exist at origin. Proceeding... 🚀"
+
+echo "--- Downloading gh"
+GH_VERSION="2.57.0"
+ARCH=$(uname -m)
+case "${ARCH}" in
+  x86_64)  GH_ARCH="amd64" ;;
+  aarch64) GH_ARCH="arm64" ;;
+  *)
+    echo "Error: Unsupported architecture: ${ARCH}"
+    exit 1
+    ;;
+esac
+
+GH_DIR="gh_${GH_VERSION}_linux_${GH_ARCH}"
+curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/${GH_DIR}.tar.gz" | tar xz
+
+echo "--- Logging in to gh"
+"${GH_DIR}/bin/gh" auth setup-git
+
+echo "+++ Tagging ${BUILDKITE_COMMIT} with ${TAG}"
+git tag "${TAG}"
+git push origin "${TAG}"


### PR DESCRIPTION
## Description

This PR moves the release process for this plugin from GitHub Actions to Buildkite. This ensures that releases always require **both** a git tag **and** binaries built with `goreleaser`, making the process more reliable and consistent.

### What's changed

- **`.buildkite/pipeline.yml`** :  adds an `Allow this build to run?` block step (security gate for public contributions) and a `Create a release?` input step on `main` builds that allows `support` and `deploy` teams to trigger a patch, minor, or major release. After unblocking, `tag.sh` pushes the git tag which triggers the release pipeline.

- **`.buildkite/pipeline.release.yml`** :  new privileged release pipeline that runs shellcheck, lint, test and build gates before running `goreleaser release --clean` to build multi-platform binaries and publish the GitHub Release.

- **`.buildkite/tag.sh`** : calculates the next semantic version from the latest git tag based on the selected release type (patch/minor/major) and pushes the tag to GitHub. Major releases require manual tagging to prevent accidents.

### Infrastructure

The following infrastructure was set up as part of this work:

- GitHub PAT from `buildkite-systems` account stored in 1Password and AWS SSM
- SSM parameter: `/pipelines/buildkite/monorail-plugin-monorepo/github-token`
- SSM parameter: `/pipelines/buildkite/monorail-plugin-monorepo-diff-release/github-token`
- IAM role: `pipeline-buildkite-monorail-plugin-monorepo` (via `aws-buildkite-dev`)
- IAM role: `pipeline-buildkite-monorail-plugin-monorepo-diff-release` (via `aws-buildkite-dev`)

### Note

`.github/workflows/publish.yml` will be deleted in a follow-up PR once the new release process has been validated end to end.