### PR TITLE
Support array config and matrix step attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+* Support `matrix` step attribute as a pass-through to the generated pipeline YAML
+* Allow `config` to be a list of step configs, each becoming an independent generated step
+
 ## [v1.11.0](https://github.com/buildkite-plugins/monorepo-diff-buildkite-plugin/compare/v1.10.0...v1.11.0) (2026-07-03)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -144,6 +144,34 @@ The plugin validates all step configurations before uploading the pipeline. Inva
       - command: "deploy.sh"
 ```
 
+#### Multiple steps per `config`
+
+`config` can also be a list of step configs instead of a single object. Each entry becomes an independent generated step (they are **not** nested under an implicit group) — the same path/`skip_path`/`except_path` matching rules that apply to a single-object `config` apply equally to every entry in the list.
+
+```yaml
+- path: services/api/
+  config:
+    - command: "npm test"
+      label: "Test API"
+    - trigger: "api-deploy"
+      label: "Deploy API"
+```
+
+When a file under `services/api/` changes, both the `npm test` command step and the `api-deploy` trigger step are generated as separate top-level steps.
+
+#### `matrix`
+
+A step's `config` can include a [build matrix](https://buildkite.com/docs/pipelines/configure/workflows/build-matrix) via the `matrix` attribute. It is passed through untouched to the generated pipeline step.
+
+```yaml
+- path: services/api/
+  config:
+    command: "test.sh"
+    matrix:
+      setup:
+        os: ["linux", "windows"]
+```
+
 #### Plugins in Step Configurations
 
 The plugin preserves `plugins:` blocks when specified in command step configurations. This allows you to use Buildkite plugins within your monorepo-watched steps.

--- a/pipeline.go
+++ b/pipeline.go
@@ -199,11 +199,11 @@ func logInvalidStep(step Step) {
 
 func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 	steps := []Step{}
-	var defaultStep *Step
+	var defaultSteps []Step
 
 	for _, w := range watch {
 		if w.Default != nil {
-			defaultStep = &w.Step
+			defaultSteps = w.Steps
 			continue
 		}
 		except := false
@@ -252,15 +252,15 @@ func stepsToTrigger(files []string, watch []WatchConfig) ([]Step, error) {
 				}
 
 				if match && !skip {
-					steps = append(steps, w.Step)
+					steps = append(steps, w.Steps...)
 					break
 				}
 			}
 		}
 	}
 
-	if len(steps) == 0 && defaultStep != nil {
-		steps = append(steps, *defaultStep)
+	if len(steps) == 0 && defaultSteps != nil {
+		steps = append(steps, defaultSteps...)
 	}
 
 	deduped := dedupSteps(steps)

--- a/pipeline_test.go
+++ b/pipeline_test.go
@@ -251,7 +251,7 @@ func TestStepsToTriggerWithEmojiPaths(t *testing.T) {
 	watch := []WatchConfig{
 		{
 			Paths: []string{"projects/**"},
-			Step:  Step{Trigger: "test-pipeline"},
+			Steps: []Step{{Trigger: "test-pipeline"}},
 		},
 	}
 
@@ -271,19 +271,19 @@ func TestPipelinesToTriggerGetsListOfPipelines(t *testing.T) {
 	watch := []WatchConfig{
 		{
 			Paths: []string{"watch-path-1"},
-			Step:  Step{Trigger: "service-1"},
+			Steps: []Step{{Trigger: "service-1"}},
 		},
 		{
 			Paths: []string{"watch-path-2/", "watch-path-3/", "watch-path-4"},
-			Step:  Step{Trigger: "service-2"},
+			Steps: []Step{{Trigger: "service-2"}},
 		},
 		{
 			Paths: []string{"watch-path-5"},
-			Step:  Step{Trigger: "service-3"},
+			Steps: []Step{{Trigger: "service-3"}},
 		},
 		{
 			Paths: []string{"watch-path-2"},
-			Step:  Step{Trigger: "service-4"},
+			Steps: []Step{{Trigger: "service-4"}},
 		},
 	}
 
@@ -318,7 +318,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			},
 			WatchConfigs: []WatchConfig{{
 				Paths: []string{"watch-path-1"},
-				Step:  Step{Trigger: "service-1"},
+				Steps: []Step{{Trigger: "service-1"}},
 			}},
 			Expected: []Step{
 				{Trigger: "service-1"},
@@ -332,11 +332,11 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"watch-path-1"},
-					Step:  Step{Trigger: "service-1"},
+					Steps: []Step{{Trigger: "service-1"}},
 				},
 				{
 					Paths: []string{"watch-path-2"},
-					Step:  Step{Trigger: "service-2"},
+					Steps: []Step{{Trigger: "service-2"}},
 				},
 			},
 			Expected: []Step{
@@ -352,7 +352,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"*.txt"},
-					Step:  Step{Trigger: "txt"},
+					Steps: []Step{{Trigger: "txt"}},
 				},
 			},
 			Expected: []Step{
@@ -366,7 +366,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"docs/*.txt"},
-					Step:  Step{Trigger: "txt"},
+					Steps: []Step{{Trigger: "txt"}},
 				},
 			},
 			Expected: []Step{
@@ -380,7 +380,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"**/text.txt"},
-					Step:  Step{Trigger: "txt"},
+					Steps: []Step{{Trigger: "txt"}},
 				},
 			},
 			Expected: []Step{
@@ -394,7 +394,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"*/*.txt"},
-					Step:  Step{Trigger: "txt"},
+					Steps: []Step{{Trigger: "txt"}},
 				},
 			},
 			Expected: []Step{
@@ -408,7 +408,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"**/*.txt"},
-					Step:  Step{Trigger: "txt"},
+					Steps: []Step{{Trigger: "txt"}},
 				},
 			},
 			Expected: []Step{
@@ -422,15 +422,15 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"app/"},
-					Step:  Step{Trigger: "app-deploy"},
+					Steps: []Step{{Trigger: "app-deploy"}},
 				},
 				{
 					Paths: []string{"test/bin/"},
-					Step:  Step{Command: "echo Make Changes to Bin"},
+					Steps: []Step{{Command: "echo Make Changes to Bin"}},
 				},
 				{
 					Default: struct{}{},
-					Step:    Step{Command: "buildkite-agent pipeline upload other_tests.yml"},
+					Steps:   []Step{{Command: "buildkite-agent pipeline upload other_tests.yml"}},
 				},
 			},
 			Expected: []Step{
@@ -444,12 +444,12 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"watch-path"},
-					Step:  Step{Trigger: "service-1"},
+					Steps: []Step{{Trigger: "service-1"}},
 				},
 				{
 					Paths:     []string{"watch-path"},
 					SkipPaths: []string{"watch-path/text.txt"},
-					Step:      Step{Trigger: "service-2"},
+					Steps:     []Step{{Trigger: "service-2"}},
 				},
 			},
 			Expected: []Step{
@@ -463,12 +463,12 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"*.txt"},
-					Step:  Step{Trigger: "service-1"},
+					Steps: []Step{{Trigger: "service-1"}},
 				},
 				{
 					Paths:     []string{"*.txt"},
 					SkipPaths: []string{"*.secret.txt"},
-					Step:      Step{Trigger: "service-2"},
+					Steps:     []Step{{Trigger: "service-2"}},
 				},
 			},
 			Expected: []Step{
@@ -482,12 +482,12 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"**/*.txt"},
-					Step:  Step{Trigger: "service-1"},
+					Steps: []Step{{Trigger: "service-1"}},
 				},
 				{
 					Paths:     []string{"**/*.txt"},
 					SkipPaths: []string{"docs/*.txt"},
-					Step:      Step{Trigger: "service-2"},
+					Steps:     []Step{{Trigger: "service-2"}},
 				},
 			},
 			Expected: []Step{
@@ -502,12 +502,12 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					Paths: []string{"**/*.txt"},
-					Step:  Step{Trigger: "service-1"},
+					Steps: []Step{{Trigger: "service-1"}},
 				},
 				{
 					Paths:     []string{"**/*.txt"},
 					SkipPaths: []string{"docs/*.secret.txt"},
-					Step:      Step{Trigger: "service-2"},
+					Steps:     []Step{{Trigger: "service-2"}},
 				},
 			},
 			Expected: []Step{
@@ -522,7 +522,7 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 			WatchConfigs: []WatchConfig{
 				{
 					SkipPaths: []string{"docs/*.secret.txt"},
-					Step:      Step{Trigger: "service-1"},
+					Steps:     []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{},
@@ -537,11 +537,11 @@ func TestPipelinesStepsToTrigger(t *testing.T) {
 				{
 					Paths:       []string{"**/*"},
 					ExceptPaths: []string{"main/other/**/*"},
-					Step:        Step{Trigger: "service-1"},
+					Steps:       []Step{{Trigger: "service-1"}},
 				},
 				{
 					Paths: []string{"main/other/**/*"},
-					Step:  Step{Trigger: "service-2"},
+					Steps: []Step{{Trigger: "service-2"}},
 				},
 			},
 			Expected: []Step{
@@ -574,7 +574,7 @@ func TestRegexPaths(t *testing.T) {
 				{
 					Paths:      []string{`src/(?!__tests__/).*\.[tj]sx?`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{
@@ -589,7 +589,7 @@ func TestRegexPaths(t *testing.T) {
 				{
 					Paths:      []string{`src/(?!__tests__/).*\.[tj]sx?`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{},
@@ -602,7 +602,7 @@ func TestRegexPaths(t *testing.T) {
 				{
 					Paths:      []string{`src/(?!pulumi|ci-generators|desktop|mobile|test)(?!.*\.test\.)(?!.*\.snap$)(?!.*/__test__/)(?!.*/__mocks__/)(?!.*/__snapshots__/).*\.[tj]sx?`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{
@@ -619,7 +619,7 @@ func TestRegexPaths(t *testing.T) {
 					Paths:      []string{`src/.*\.[tj]sx?`},
 					SkipPaths:  []string{`.*\.test\.[tj]sx?`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{
@@ -635,7 +635,7 @@ func TestRegexPaths(t *testing.T) {
 					Paths:       []string{`src/.*`},
 					ExceptPaths: []string{`src/generated/.*`},
 					RegexPaths:  true,
-					Step:        Step{Trigger: "service-1"},
+					Steps:       []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{},
@@ -648,7 +648,7 @@ func TestRegexPaths(t *testing.T) {
 				{
 					Paths:      []string{`src/[invalid`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected:    []Step{},
@@ -662,7 +662,7 @@ func TestRegexPaths(t *testing.T) {
 				{
 					Paths:      []string{`src/**/*.tsx`},
 					RegexPaths: false,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{
@@ -678,11 +678,11 @@ func TestRegexPaths(t *testing.T) {
 				{
 					Paths:      []string{`src/(?!__tests__/).*\.tsx`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "frontend"},
+					Steps:      []Step{{Trigger: "frontend"}},
 				},
 				{
 					Paths: []string{"services/api/"},
-					Step:  Step{Trigger: "backend"},
+					Steps: []Step{{Trigger: "backend"}},
 				},
 			},
 			Expected: []Step{
@@ -699,7 +699,7 @@ func TestRegexPaths(t *testing.T) {
 					Paths:      []string{`src/.*`},
 					SkipPaths:  []string{`src/[invalid`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected:    []Step{},
@@ -713,7 +713,7 @@ func TestRegexPaths(t *testing.T) {
 				{
 					Paths:      []string{`src/.*\.go`},
 					RegexPaths: true,
-					Step:       Step{Trigger: "service-1"},
+					Steps:      []Step{{Trigger: "service-1"}},
 				},
 			},
 			Expected: []Step{},
@@ -1537,11 +1537,11 @@ func TestStepsToTrigger_Issue83(t *testing.T) {
 	watch := []WatchConfig{
 		{
 			Paths: []string{"some-path/**"},
-			Step:  Step{}, // Empty step - should be filtered
+			Steps: []Step{{}}, // Empty step - should be filtered
 		},
 		{
 			Paths: []string{"other-path/**"},
-			Step:  Step{Command: "echo valid"},
+			Steps: []Step{{Command: "echo valid"}},
 		},
 	}
 
@@ -1562,11 +1562,11 @@ func TestStepsToTrigger_DefaultWithEmptyStep(t *testing.T) {
 	watch := []WatchConfig{
 		{
 			Paths: []string{"app/"},
-			Step:  Step{Command: "echo app"},
+			Steps: []Step{{Command: "echo app"}},
 		},
 		{
 			Default: struct{}{},
-			Step:    Step{}, // Empty default - should be filtered
+			Steps:   []Step{{}}, // Empty default - should be filtered
 		},
 	}
 
@@ -1583,11 +1583,11 @@ func TestStepsToTrigger_AllStepsInvalid(t *testing.T) {
 	watch := []WatchConfig{
 		{
 			Paths: []string{"path1/"},
-			Step:  Step{},
+			Steps: []Step{{}},
 		},
 		{
 			Paths: []string{"path2/"},
-			Step:  Step{Label: "no command"},
+			Steps: []Step{{Label: "no command"}},
 		},
 	}
 
@@ -1604,10 +1604,10 @@ func TestStepsToTrigger_EmptyGroupInConfig(t *testing.T) {
 	watch := []WatchConfig{
 		{
 			Paths: []string{"services/"},
-			Step: Step{
+			Steps: []Step{{
 				Group: "deploy",
 				Steps: []Step{}, // Empty group
-			},
+			}},
 		},
 	}
 
@@ -1624,15 +1624,15 @@ func TestStepsToTrigger_ValidAndInvalidStepsMixed(t *testing.T) {
 	watch := []WatchConfig{
 		{
 			Paths: []string{"app/"},
-			Step:  Step{Command: "echo valid app"},
+			Steps: []Step{{Command: "echo valid app"}},
 		},
 		{
 			Paths: []string{"tests/"},
-			Step:  Step{}, // Invalid
+			Steps: []Step{{}}, // Invalid
 		},
 		{
 			Paths: []string{"deploy/"},
-			Step:  Step{Trigger: "deploy-pipeline"},
+			Steps: []Step{{Trigger: "deploy-pipeline"}},
 		},
 	}
 

--- a/plugin.go
+++ b/plugin.go
@@ -37,7 +37,8 @@ type HookConfig struct {
 type WatchConfig struct {
 	RawPath       interface{} `json:"path"`
 	Paths         []string
-	Step          Step        `json:"config"`
+	RawConfig     interface{} `json:"config"`
+	Steps         []Step
 	Default       interface{} `json:"default"`
 	RawSkipPath   interface{} `json:"skip_path"`
 	RawExceptPath interface{} `json:"except_path"`
@@ -105,6 +106,7 @@ type Step struct {
 	Secrets                interface{}              `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 	Steps                  []Step                   `yaml:"steps,omitempty"`
 	AllowDependencyFailure bool                     `json:"allow_dependency_failure,omitempty" yaml:"allow_dependency_failure,omitempty"`
+	Matrix                 interface{}              `yaml:"matrix,omitempty"`
 }
 
 // isValid checks if a step has required fields (command, trigger, or group with steps)
@@ -229,16 +231,28 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 		if p.Default != nil {
 			plugin.Watch[i].Paths = []string{}
 			if config, ok := p.Default.(map[string]interface{}); ok && len(config) > 0 {
-				// Use the default config directly
-				conf := config
-				if _, ok := config["config"]; ok {
-					// or allow for it to be in a config configuration
-					conf = config["config"].(map[string]interface{})
+				var conf interface{} = config
+				if nested, ok := config["config"]; ok {
+					conf = nested
 				}
-				b, _ := json.Marshal(conf)
-				err := json.Unmarshal(b, &plugin.Watch[i].Step)
+				b, err := json.Marshal(conf)
 				if err != nil {
 					return err
+				}
+
+				switch conf.(type) {
+				case []interface{}:
+					var steps []Step
+					if err := json.Unmarshal(b, &steps); err != nil {
+						return err
+					}
+					plugin.Watch[i].Steps = steps
+				default:
+					var step Step
+					if err := json.Unmarshal(b, &step); err != nil {
+						return err
+					}
+					plugin.Watch[i].Steps = []Step{step}
 				}
 			}
 			plugin.Watch[i].Default = true
@@ -273,12 +287,37 @@ func (plugin *Plugin) UnmarshalJSON(data []byte) error {
 			}
 		}
 
-		if plugin.Watch[i].Step.Trigger != "" {
-			setBuild(&plugin.Watch[i].Step.Build)
-		}
+		if p.RawConfig != nil {
+			b, err := json.Marshal(p.RawConfig)
+			if err != nil {
+				return fmt.Errorf("failed to parse config: %v", err)
+			}
 
-		if plugin.Watch[i].Step.RawNotify != nil {
-			setNotify(&plugin.Watch[i].Step.Notify, &plugin.Watch[i].Step.RawNotify)
+			switch p.RawConfig.(type) {
+			case []interface{}:
+				var steps []Step
+				if err := json.Unmarshal(b, &steps); err != nil {
+					return fmt.Errorf("failed to parse config: %v", err)
+				}
+				plugin.Watch[i].Steps = steps
+			default:
+				var step Step
+				if err := json.Unmarshal(b, &step); err != nil {
+					return fmt.Errorf("failed to parse config: %v", err)
+				}
+				plugin.Watch[i].Steps = []Step{step}
+			}
+		}
+		plugin.Watch[i].RawConfig = nil
+
+		for j := range plugin.Watch[i].Steps {
+			step := &plugin.Watch[i].Steps[j]
+			if step.Trigger != "" {
+				setBuild(&step.Build)
+			}
+			if step.RawNotify != nil {
+				setNotify(&step.Notify, &step.RawNotify)
+			}
 		}
 
 		appendEnv(&plugin.Watch[i], plugin.Env)
@@ -469,34 +508,39 @@ func processNestedSteps(steps []Step, env map[string]string) {
 
 // appends top level env to Step.Env and Step.Build.Env
 func appendEnv(watch *WatchConfig, env map[string]string) {
-	watch.Step.Env, _ = parseEnv(watch.Step.RawEnv)
-	watch.Step.Build.Env, _ = parseEnv(watch.Step.Build.RawEnv)
+	for i := range watch.Steps {
+		step := &watch.Steps[i]
 
-	for key, value := range env {
-		if watch.Step.Command != nil || watch.Step.Commands != nil {
-			if watch.Step.Env == nil {
-				watch.Step.Env = make(map[string]string)
+		step.Env, _ = parseEnv(step.RawEnv)
+		step.Build.Env, _ = parseEnv(step.Build.RawEnv)
+
+		for key, value := range env {
+			if step.Command != nil || step.Commands != nil {
+				if step.Env == nil {
+					step.Env = make(map[string]string)
+				}
+
+				step.Env[key] = value
+				continue
 			}
+			if step.Trigger != "" {
+				if step.Build.Env == nil {
+					step.Build.Env = make(map[string]string)
+				}
 
-			watch.Step.Env[key] = value
-			continue
+				step.Build.Env[key] = value
+				continue
+			}
 		}
-		if watch.Step.Trigger != "" {
-			if watch.Step.Build.Env == nil {
-				watch.Step.Build.Env = make(map[string]string)
-			}
 
-			watch.Step.Build.Env[key] = value
-			continue
+		step.RawEnv = nil
+		step.Build.RawEnv = nil
+		// Process nested steps
+		if len(step.Steps) > 0 {
+			processNestedSteps(step.Steps, env)
 		}
 	}
 
-	watch.Step.RawEnv = nil
-	watch.Step.Build.RawEnv = nil
-	// Process nested steps
-	if len(watch.Step.Steps) > 0 {
-		processNestedSteps(watch.Step.Steps, env)
-	}
 	watch.RawPath = nil
 	watch.RawSkipPath = nil
 }
@@ -506,13 +550,16 @@ func appendMetadata(watch *WatchConfig, metadata map[string]string) {
 	if len(metadata) == 0 {
 		return
 	}
-	// Only apply metadata to trigger steps, not command steps
-	if watch.Step.Trigger != "" {
-		if watch.Step.Build.Metadata == nil {
-			watch.Step.Build.Metadata = make(map[string]string)
-		}
-		for k, v := range metadata {
-			watch.Step.Build.Metadata[k] = v
+	for i := range watch.Steps {
+		step := &watch.Steps[i]
+		// Only apply metadata to trigger steps, not command steps
+		if step.Trigger != "" {
+			if step.Build.Metadata == nil {
+				step.Build.Metadata = make(map[string]string)
+			}
+			for k, v := range metadata {
+				step.Build.Metadata[k] = v
+			}
 		}
 	}
 }

--- a/plugin.yml
+++ b/plugin.yml
@@ -54,7 +54,7 @@ configuration:
             When true, path, skip_path, and except_path are treated as regexp2 regular expressions
             instead of globs. Supports full PCRE syntax including lookaheads.
         config:
-          type: object
+          type: [object, array]
           properties:
             group:
               type: string
@@ -72,6 +72,12 @@ configuration:
               type: string
             soft_fail:
               type: [object, boolean]
+            matrix:
+              type: [array, object]
+              description: >
+                Build matrix configuration; either a list of values or an object with
+                "setup" and "adjustments". Passed through untouched to the generated step.
+                See https://buildkite.com/docs/pipelines/configure/workflows/build-matrix
             notify:
               type: [array]
               properties:

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
 )
 
 func defaultPlugin() Plugin {
@@ -22,18 +24,18 @@ func defaultPluginWithDefault() Plugin {
 	ret.Watch = []WatchConfig{
 		{
 			Paths: []string{".buildkite/**/*"},
-			Step: Step{
+			Steps: []Step{{
 				Command: "echo hello world",
 				Label:   "Example label",
-			},
+			}},
 		},
 		{
 			Default: true,
 			Paths:   []string{},
-			Step: Step{
+			Steps: []Step{{
 				Command: "echo default hello world",
 				Label:   "Default label",
-			},
+			}},
 		},
 	}
 
@@ -221,7 +223,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"watch-path-1"},
-				Step: Step{
+				Steps: []Step{{
 					Trigger: "service-2",
 					Build: Build{
 						Message: "some message",
@@ -234,11 +236,11 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 							"env3": "env-3",
 						},
 					},
-				},
+				}},
 			},
 			{
 				Paths: []string{"watch-path-1"},
-				Step: Step{
+				Steps: []Step{{
 					Command: "echo hello-world",
 					Env: map[string]string{
 						"env1": "env-1",
@@ -264,11 +266,11 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						{GithubStatus: GithubStatusNotification{Context: "my-custom-status"}},
 						{Slack: "@someuser", Condition: "build.state === 'passed'"},
 					},
-				},
+				}},
 			},
 			{
 				Paths: []string{"watch-path-1", "watch-path-2"},
-				Step: Step{
+				Steps: []Step{{
 					Trigger: "service-1",
 					Label:   "hello",
 					Build: Build{
@@ -294,11 +296,11 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 					SoftFail: []interface{}{map[string]interface{}{
 						"exit_status": float64(127),
 					}},
-				},
+				}},
 			},
 			{
 				Paths: []string{"watch-path-1"},
-				Step: Step{
+				Steps: []Step{{
 					Group:   "my group",
 					Command: "echo hello-group",
 					Env: map[string]string{
@@ -307,11 +309,11 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 						"env3": "env-3",
 					},
 					SoftFail: true,
-				},
+				}},
 			},
 			{
 				Paths: []string{"watch-path-3"},
-				Step: Step{
+				Steps: []Step{{
 					Group: "my group",
 					Steps: []Step{
 						{
@@ -331,7 +333,7 @@ func TestPluginShouldUnmarshallCorrectly(t *testing.T) {
 							},
 						},
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -544,14 +546,14 @@ func TestPluginWithBuildConfigFromEnv(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{".buildkite/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Trigger: "foo-service",
 					Build: Build{
 						Message: "fix: temp file not correctly deleted",
 						Branch:  "go-rewrite",
 						Commit:  "123",
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -629,25 +631,25 @@ func TestPluginWithMultiplePluginVersions(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"foo-service/"},
-				Step: Step{
+				Steps: []Step{{
 					Trigger: "foo-service",
 					Build: Build{
 						Message: "fix: temp file not correctly deleted",
 						Branch:  "go-rewrite",
 						Commit:  "123",
 					},
-				},
+				}},
 			},
 			{
 				Paths: []string{"bar-service/"},
-				Step: Step{
+				Steps: []Step{{
 					Trigger: "foo-service",
 					Build: Build{
 						Message: "fix: temp file not correctly deleted",
 						Branch:  "go-rewrite",
 						Commit:  "123",
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -685,11 +687,11 @@ func TestPluginShouldPreserveStepPlugins(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{".buildkite/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Plugins: []map[string]interface{}{
 						{"some-plugin#v1": map[string]interface{}{"foo": "bar"}},
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -725,9 +727,9 @@ func TestPluginShouldPreserveStepBranches(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{".buildkite/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Branches: "!main feature/*",
-				},
+				}},
 			},
 		},
 	}
@@ -779,7 +781,7 @@ func TestPluginMetadataOnlyAppliedToTriggerSteps(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"app/"},
-				Step: Step{
+				Steps: []Step{{
 					Trigger: "app-deploy",
 					Build: Build{
 						Message: "fix: temp file not correctly deleted",
@@ -790,17 +792,17 @@ func TestPluginMetadataOnlyAppliedToTriggerSteps(t *testing.T) {
 							"plugin_level_key": "plugin_level_value",
 						},
 					},
-				},
+				}},
 			},
 			{
 				Paths: []string{"test/"},
-				Step: Step{
+				Steps: []Step{{
 					Command: "echo test command",
 					// Build defaults are not set for command steps
 					Build: Build{
 						// No metadata should be set here
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -810,11 +812,11 @@ func TestPluginMetadataOnlyAppliedToTriggerSteps(t *testing.T) {
 	}
 
 	// Explicitly verify that command step doesn't have metadata
-	commandStep := got.Watch[1].Step
+	commandStep := got.Watch[1].Steps[0]
 	assert.Nil(t, commandStep.Build.Metadata, "Command step should not have metadata set")
 
 	// Explicitly verify that trigger step has metadata
-	triggerStep := got.Watch[0].Step
+	triggerStep := got.Watch[0].Steps[0]
 	assert.NotNil(t, triggerStep.Build.Metadata, "Trigger step should have metadata set")
 	assert.Equal(t, "step_level_value", triggerStep.Build.Metadata["step_level_key"])
 	assert.Equal(t, "plugin_level_value", triggerStep.Build.Metadata["plugin_level_key"])
@@ -849,13 +851,13 @@ func TestPluginLevelMetadataNotAppliedToCommandSteps(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify that trigger step gets plugin-level metadata
-	triggerStep := got.Watch[0].Step
+	triggerStep := got.Watch[0].Steps[0]
 	assert.Equal(t, "app-deploy", triggerStep.Trigger)
 	assert.NotNil(t, triggerStep.Build.Metadata)
 	assert.Equal(t, "bar", triggerStep.Build.Metadata["foo"])
 
 	// Verify that command step does NOT get plugin-level metadata
-	commandStep := got.Watch[1].Step
+	commandStep := got.Watch[1].Steps[0]
 	assert.Equal(t, "echo Make Changes to Bin", commandStep.Command)
 	assert.Nil(t, commandStep.Build.Metadata, "Command step should not have metadata applied")
 }
@@ -886,10 +888,10 @@ func TestPluginShouldPreserveStepCondition(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"service/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Command:   "echo deploy",
 					Condition: "build.branch == 'main' && build.pull_request.id == null",
-				},
+				}},
 			},
 		},
 	}
@@ -944,16 +946,16 @@ func TestPluginShouldClearRawEnvFromNestedSteps(t *testing.T) {
 
 	// Verify the structure is correct
 	assert.Equal(t, 1, len(got.Watch))
-	assert.Equal(t, "test-group", got.Watch[0].Step.Group)
-	assert.Equal(t, 2, len(got.Watch[0].Step.Steps))
+	assert.Equal(t, "test-group", got.Watch[0].Steps[0].Group)
+	assert.Equal(t, 2, len(got.Watch[0].Steps[0].Steps))
 
 	// Verify nested steps have correct env values
-	firstStep := got.Watch[0].Step.Steps[0]
+	firstStep := got.Watch[0].Steps[0].Steps[0]
 	assert.Equal(t, "test-pipeline", firstStep.Trigger)
 	assert.Equal(t, "pr", firstStep.Build.Env["BUNDLE_BUILD"])
 	assert.Equal(t, "plugin-value", firstStep.Build.Env["PLUGIN_ENV"])
 
-	secondStep := got.Watch[0].Step.Steps[1]
+	secondStep := got.Watch[0].Steps[0].Steps[1]
 	assert.Equal(t, "test-pipeline", secondStep.Trigger)
 	assert.Equal(t, "master", secondStep.Build.Env["BUNDLE_BUILD"])
 	assert.Equal(t, "plugin-value", secondStep.Build.Env["PLUGIN_ENV"])
@@ -990,9 +992,9 @@ func TestPluginShouldProcessNotifyInNestedSteps(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Verify nested step exists
-	assert.Equal(t, 1, len(got.Watch[0].Step.Steps))
+	assert.Equal(t, 1, len(got.Watch[0].Steps[0].Steps))
 
-	nestedStep := got.Watch[0].Step.Steps[0]
+	nestedStep := got.Watch[0].Steps[0].Steps[0]
 
 	// Verify RawNotify is cleared
 	assert.Nil(t, nestedStep.RawNotify, "RawNotify should be nil after processing")
@@ -1028,10 +1030,10 @@ func TestPluginShouldPreserveDependsOnString(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"service/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Command:   "echo deploy",
 					DependsOn: "build-step",
-				},
+				}},
 			},
 		},
 	}
@@ -1067,7 +1069,7 @@ func TestPluginShouldPreserveDependsOnArray(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"service/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Trigger: "deploy-pipeline",
 					Build: Build{
 						Message: "fix: temp file not correctly deleted",
@@ -1075,7 +1077,7 @@ func TestPluginShouldPreserveDependsOnArray(t *testing.T) {
 						Commit:  "123",
 					},
 					DependsOn: []interface{}{"build-step", "test-step"},
-				},
+				}},
 			},
 		},
 	}
@@ -1122,7 +1124,7 @@ func TestPluginEnvWithEqualsSignsAndSpacesInValues(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"services/"},
-				Step: Step{
+				Steps: []Step{{
 					Command: "echo test",
 					Env: map[string]string{
 						"EXTRA_BUILD_ARGS": "--build-arg=ARG1=value1",
@@ -1130,7 +1132,7 @@ func TestPluginEnvWithEqualsSignsAndSpacesInValues(t *testing.T) {
 						"SPACE_VALUE":      "value with spaces",
 						"COMPLEX":          "\"--opt1=val1 --opt2=val2\"",
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -1175,13 +1177,13 @@ func TestPluginShouldPreserveSecretsAsMap(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"service/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Command: "echo deploy",
 					Secrets: map[string]interface{}{
 						"DATABRICKS_HOST":  "databricks_host_secret",
 						"DATABRICKS_TOKEN": "databricks_token_secret",
 					},
-				},
+				}},
 			},
 		},
 	}
@@ -1217,10 +1219,10 @@ func TestPluginShouldPreserveSecretsAsArray(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"service/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Command: "echo deploy",
 					Secrets: []interface{}{"API_ACCESS_TOKEN", "DATABASE_PASSWORD"},
-				},
+				}},
 			},
 		},
 	}
@@ -1262,18 +1264,18 @@ func TestPluginShouldPreserveSecretsInNestedSteps(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, 1, len(got.Watch))
-	assert.Equal(t, "deploy group", got.Watch[0].Step.Group)
-	assert.Equal(t, 2, len(got.Watch[0].Step.Steps))
+	assert.Equal(t, "deploy group", got.Watch[0].Steps[0].Group)
+	assert.Equal(t, 2, len(got.Watch[0].Steps[0].Steps))
 
 	// Verify first nested step has secrets as map
-	firstStep := got.Watch[0].Step.Steps[0]
+	firstStep := got.Watch[0].Steps[0].Steps[0]
 	assert.Equal(t, "echo deploy uat", firstStep.Command)
 	secretsMap, ok := firstStep.Secrets.(map[string]interface{})
 	assert.True(t, ok, "first step secrets should be a map")
 	assert.Equal(t, "uat_db_host", secretsMap["DB_HOST"])
 
 	// Verify second nested step has secrets as array
-	secondStep := got.Watch[0].Step.Steps[1]
+	secondStep := got.Watch[0].Steps[0].Steps[1]
 	assert.Equal(t, "echo deploy prod", secondStep.Command)
 	secretsArray, ok := secondStep.Secrets.([]interface{})
 	assert.True(t, ok, "second step secrets should be an array")
@@ -1307,10 +1309,10 @@ func TestPluginAcceptsArtifactPathsFieldName(t *testing.T) {
 		Watch: []WatchConfig{
 			{
 				Paths: []string{"service/**/*"},
-				Step: Step{
+				Steps: []Step{{
 					Command:       "echo test",
 					ArtifactPaths: []string{"logs/**/*", "coverage/**/*"},
-				},
+				}},
 			},
 		},
 	}
@@ -1590,9 +1592,9 @@ func TestStepWithMapEnv(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, got.Watch, 1)
-	assert.Equal(t, "test", got.Watch[0].Step.Env["NODE_ENV"])
-	assert.Equal(t, "4", got.Watch[0].Step.Env["MAX_WORKERS"])
-	assert.Equal(t, "true", got.Watch[0].Step.Env["COVERAGE"])
+	assert.Equal(t, "test", got.Watch[0].Steps[0].Env["NODE_ENV"])
+	assert.Equal(t, "4", got.Watch[0].Steps[0].Env["MAX_WORKERS"])
+	assert.Equal(t, "true", got.Watch[0].Steps[0].Env["COVERAGE"])
 }
 
 func TestBuildWithMapEnv(t *testing.T) {
@@ -1620,8 +1622,8 @@ func TestBuildWithMapEnv(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, got.Watch, 1)
-	assert.Equal(t, "staging", got.Watch[0].Step.Build.Env["DEPLOY_ENV"])
-	assert.Equal(t, "3", got.Watch[0].Step.Build.Env["REPLICAS"])
+	assert.Equal(t, "staging", got.Watch[0].Steps[0].Build.Env["DEPLOY_ENV"])
+	assert.Equal(t, "3", got.Watch[0].Steps[0].Build.Env["REPLICAS"])
 }
 
 func TestNestedStepsWithMapEnv(t *testing.T) {
@@ -1657,9 +1659,9 @@ func TestNestedStepsWithMapEnv(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Len(t, got.Watch, 1)
-	assert.Len(t, got.Watch[0].Step.Steps, 2)
-	assert.Equal(t, "value1", got.Watch[0].Step.Steps[0].Env["TEST"])
-	assert.Equal(t, "value2", got.Watch[0].Step.Steps[1].Env["TEST"])
+	assert.Len(t, got.Watch[0].Steps[0].Steps, 2)
+	assert.Equal(t, "value1", got.Watch[0].Steps[0].Steps[0].Env["TEST"])
+	assert.Equal(t, "value2", got.Watch[0].Steps[0].Steps[1].Env["TEST"])
 }
 
 func TestMixedEnvFormats(t *testing.T) {
@@ -1692,8 +1694,8 @@ func TestMixedEnvFormats(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "plugin-value", got.Env["PLUGIN_VAR"])
 	assert.Equal(t, "from-env", got.Env["GLOBAL_VAR"])
-	assert.Equal(t, "step-value", got.Watch[0].Step.Env["STEP_VAR"])
-	assert.Equal(t, "8080", got.Watch[0].Step.Env["PORT"])
+	assert.Equal(t, "step-value", got.Watch[0].Steps[0].Env["STEP_VAR"])
+	assert.Equal(t, "8080", got.Watch[0].Steps[0].Env["PORT"])
 }
 
 func TestMapEnvWithOSEnvReading(t *testing.T) {
@@ -1858,4 +1860,84 @@ func TestPluginParsesRegexPaths(t *testing.T) {
 	got, err := initializePlugin(param)
 	assert.NoError(t, err)
 	assert.True(t, got.Watch[0].RegexPaths)
+}
+
+func TestPluginConfigSingleObjectProducesOneStep(t *testing.T) {
+	// Regression check: a single step object under "config" (today's
+	// existing form) must still produce exactly one entry in Steps.
+	param := `[{
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
+			"watch": [
+				{
+					"path": "services/",
+					"config": {
+						"command": "echo test"
+					}
+				}
+			]
+		}
+	}]`
+
+	got, err := initializePlugin(param)
+	assert.NoError(t, err)
+	assert.Len(t, got.Watch, 1)
+	assert.Len(t, got.Watch[0].Steps, 1)
+	assert.Equal(t, "echo test", got.Watch[0].Steps[0].Command)
+}
+
+func TestPluginConfigArrayProducesMultipleSteps(t *testing.T) {
+	// "config" can also be an array of step objects, each becoming an
+	// independent generated step (not nested in an implicit group).
+	param := `[{
+		"github.com/buildkite-plugins/monorepo-diff-buildkite-plugin#commit": {
+			"watch": [
+				{
+					"path": "services/",
+					"config": [
+						{ "command": "echo first step" },
+						{ "trigger": "downstream-pipeline" }
+					]
+				}
+			]
+		}
+	}]`
+
+	got, err := initializePlugin(param)
+	assert.NoError(t, err)
+	assert.Len(t, got.Watch, 1)
+	assert.Len(t, got.Watch[0].Steps, 2)
+	assert.Equal(t, "echo first step", got.Watch[0].Steps[0].Command)
+	assert.Equal(t, "downstream-pipeline", got.Watch[0].Steps[1].Trigger)
+
+	// stepsToTrigger / pipeline generation should produce both as separate
+	// top-level steps, not nested under a group, when the path matches.
+	steps, err := stepsToTrigger([]string{"services/main.go"}, got.Watch)
+	assert.NoError(t, err)
+	assert.Len(t, steps, 2)
+	assert.Equal(t, "", steps[0].Group)
+	assert.Equal(t, "", steps[1].Group)
+	assert.Equal(t, "echo first step", steps[0].Command)
+	assert.Equal(t, "downstream-pipeline", steps[1].Trigger)
+}
+
+func TestStepMatrixRoundTripsToYAML(t *testing.T) {
+	// The "matrix" step attribute is a pure pass-through; unmarshaling it
+	// from JSON and then marshaling back to YAML should preserve it as-is.
+	data := []byte(`{
+		"command": "echo test",
+		"matrix": {"setup": {"os": ["linux", "windows"]}}
+	}`)
+
+	var step Step
+	err := json.Unmarshal(data, &step)
+	assert.NoError(t, err)
+
+	out, err := yaml.Marshal(step)
+	assert.NoError(t, err)
+
+	yamlStr := string(out)
+	assert.Contains(t, yamlStr, "matrix:")
+	assert.Contains(t, yamlStr, "setup:")
+	assert.Contains(t, yamlStr, "- linux")
+	assert.Contains(t, yamlStr, "- windows")
 }


### PR DESCRIPTION
Config under a watch entry can now be a single step object (unchanged) or an array of step objects — each array entry becomes an independent top-level generated step, using the same path/skip_path/except_path matching rules.
Added a matrix step attribute that passes through untouched to the generated pipeline YAML, supporting [Buildkite build matrices](https://buildkite.com/docs/pipelines/configure/workflows/build-matrix).

Test plan
 go build ./..., go vet ./..., gofmt -l . all clean
 go test ./... passes, including new regression/array/matrix tests
 Manual end-to-end run confirming array config + matrix produce the expected generated pipeline YAML