### PR TITLE
fix: lowercase uname -s output before building checksum lookup key

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -43,8 +43,10 @@ check_cmd() {
 }
 
 get_architecture() {
-  _ostype="$(uname -s)"
-  _arch="$(uname -m)"
+  # GoReleaser publishes checksums.txt and binary asset names with a lowercase
+  # os token (e.g. "linux_amd64"), but `uname -s` reports "Linux"/"Darwin".
+  _ostype="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  _arch="$(uname -m)" # already normalized to lowercase amd64/arm64/ppc64le below
   _arm=("arm armhf aarch64 aarch64_be armv6l armv7l armv8l arm64e") # arm64
   _amd=("x86 x86pc i386 i686 i686-64 x64 x86_64 x86_64h athlon")    # amd64
 

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -172,17 +172,19 @@ teardown() {
   stub sha256sum \
     "* : echo '${mock_binary_checksum}  monorepo-diff-buildkite-plugin'"
 
-  # Stub curl: download binary and checksums.txt
-  # Need to match all possible architectures in checksums.txt
+  # Stub curl: download binary and checksums.txt. GoReleaser publishes checksums.txt
+  # with lowercase os/arch tokens (e.g. "linux_amd64"), never "Linux_amd64", regardless
+  # of the case `uname -s`/`uname -m` report on the host running the hook.
   stub curl \
     "-fL * -o * : echo '#!/bin/bash' > \"\${4}\"; echo 'echo test' >> \"\${4}\"; exit 0" \
-    "-fL * -o * : printf '%s\n' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_Darwin_amd64' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_Darwin_arm64' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_Linux_amd64' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_Linux_arm64' > \"\${4}\"; exit 0"
+    "-fL * -o * : printf '%s\n' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_darwin_amd64' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_darwin_arm64' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_linux_amd64' '${mock_binary_checksum}  monorepo-diff-buildkite-plugin_linux_arm64' > \"\${4}\"; exit 0"
 
   run "$PWD/hooks/command"
 
   assert_success
   assert_output --partial "Download successful"
   assert_output --partial "Checksum verification passed"
+  refute_output --partial "Checksum not found in checksums.txt"
 
   unstub curl
   unstub sha256sum
@@ -208,7 +210,7 @@ teardown() {
   # Stub curl: download binary and checksums.txt (with all architectures)
   stub curl \
     "-fL * -o * : echo '#!/bin/bash' > \"\${4}\"; echo 'echo test' >> \"\${4}\"; exit 0" \
-    "-fL * -o * : printf '%s\n' '${expected_checksum}  monorepo-diff-buildkite-plugin_Darwin_amd64' '${expected_checksum}  monorepo-diff-buildkite-plugin_Darwin_arm64' '${expected_checksum}  monorepo-diff-buildkite-plugin_Linux_amd64' '${expected_checksum}  monorepo-diff-buildkite-plugin_Linux_arm64' > \"\${4}\"; exit 0"
+    "-fL * -o * : printf '%s\n' '${expected_checksum}  monorepo-diff-buildkite-plugin_darwin_amd64' '${expected_checksum}  monorepo-diff-buildkite-plugin_darwin_arm64' '${expected_checksum}  monorepo-diff-buildkite-plugin_linux_amd64' '${expected_checksum}  monorepo-diff-buildkite-plugin_linux_arm64' > \"\${4}\"; exit 0"
 
   run "$PWD/hooks/command"
 
@@ -246,9 +248,9 @@ teardown() {
 
   # Stub curl: download checksums (first check), then binary, then checksums again (recovery check)
   stub curl \
-    "-fL * -o * : printf '%s\n' '${good_checksum}  monorepo-diff-buildkite-plugin_Darwin_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_Darwin_arm64' '${good_checksum}  monorepo-diff-buildkite-plugin_Linux_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_Linux_arm64' > \"\${4}\"; exit 0" \
+    "-fL * -o * : printf '%s\n' '${good_checksum}  monorepo-diff-buildkite-plugin_darwin_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_darwin_arm64' '${good_checksum}  monorepo-diff-buildkite-plugin_linux_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_linux_arm64' > \"\${4}\"; exit 0" \
     "-fL * -o * : echo '#!/bin/bash' > \"\${4}\"; echo 'echo recovered' >> \"\${4}\"; exit 0" \
-    "-fL * -o * : printf '%s\n' '${good_checksum}  monorepo-diff-buildkite-plugin_Darwin_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_Darwin_arm64' '${good_checksum}  monorepo-diff-buildkite-plugin_Linux_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_Linux_arm64' > \"\${4}\"; exit 0"
+    "-fL * -o * : printf '%s\n' '${good_checksum}  monorepo-diff-buildkite-plugin_darwin_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_darwin_arm64' '${good_checksum}  monorepo-diff-buildkite-plugin_linux_amd64' '${good_checksum}  monorepo-diff-buildkite-plugin_linux_arm64' > \"\${4}\"; exit 0"
 
   run "$PWD/hooks/command"
 
@@ -319,7 +321,7 @@ teardown() {
   # Stub curl: download binary and checksums
   stub curl \
     "-fL * -o * : echo '#!/bin/bash' > \"\${4}\"; echo 'echo test' >> \"\${4}\"; exit 0" \
-    "-fL * -o * : echo 'abc123  monorepo-diff-buildkite-plugin_Darwin_amd64' > \"\${4}\"; exit 0"
+    "-fL * -o * : echo 'abc123  monorepo-diff-buildkite-plugin_darwin_amd64' > \"\${4}\"; exit 0"
 
   # Ensure sha256sum, shasum, and sha256 are all unavailable by stubbing command -v
   # Note: This is tricky in bats. We'll rely on the implementation checking for these commands.


### PR DESCRIPTION
## The bug

`get_architecture()` in `hooks/command` builds the lookup key used to verify a downloaded binary against `checksums.txt` (the `verify_checksum: true` option) from `uname -s` directly, without normalizing case. On Linux this produces `Linux`, on macOS `Darwin`. GoReleaser, however, publishes both the release binary assets and the `checksums.txt` entries with a lowercase os token — confirmed against the actual `v1.11.0` release assets (`monorepo-diff-buildkite-plugin_linux_amd64`, etc.) and the `checksums.txt` content for that release (`... monorepo-diff-buildkite-plugin_linux_amd64`).

Because the lookup is a literal `grep` against `checksums.txt`, the capitalized key never matches, so `verify_checksum()` always falls into the "not found" branch and silently skips verification:

```
Warning: Checksum not found in checksums.txt for monorepo-diff-buildkite-plugin_Linux_amd64, skipping verification
```

That's the exact warning seen in real CI logs from an internal Owner.com pipeline using `verify_checksum: true` at v1.11.0 — so `verify_checksum: true` has been silently defeated on Linux agents (and any other platform where `uname -s` doesn't already happen to be lowercase) since the option was introduced.

The binary *download* itself is unaffected and doesn't surface this — GitHub's release-asset redirect matches asset filenames case-insensitively, so a request for `..._Linux_amd64` transparently 302s to the real `..._linux_amd64` asset. Only the plain-text `grep` against `checksums.txt` (which has no such leniency) is affected. That's why this fails open (quiet skip + warning) instead of failing the build outright, and why it went unnoticed.

I checked `uname -m` / arch handling too: `_arch` is already normalized to lowercase (`amd64`/`arm64`/`ppc64le`) further down in `get_architecture()`, so no change was needed there — only the os token.

## The fix

One line: lowercase `uname -s` output before using it to build the lookup key.

```diff
 get_architecture() {
-  _ostype="$(uname -s)"
-  _arch="$(uname -m)"
+  # GoReleaser publishes checksums.txt and binary asset names with a lowercase
+  # os token (e.g. "linux_amd64"), but `uname -s` reports "Linux"/"Darwin".
+  _ostype="$(uname -s | tr '[:upper:]' '[:lower:]')"
+  _arch="$(uname -m)" # already normalized to lowercase amd64/arm64/ppc64le below
```

## Tests

`tests/command.bats` already has integration-style bats coverage for `verify_checksum` (tests 9–11), but their `checksums.txt` stubs encoded the same capitalized os names the buggy code produces (`monorepo-diff-buildkite-plugin_Darwin_amd64` / `_Linux_amd64`), so they passed *against* the bug rather than catching it. I corrected those stubs to the real GoReleaser convention (lowercase) and added an explicit `refute_output --partial "Checksum not found in checksums.txt"` assertion to the primary success-path test.

With that correction:
- **Before this fix**: 3 tests fail (9, 10, 11) — e.g. test 9 fails with `Warning: Checksum not found in checksums.txt for monorepo-diff-buildkite-plugin_Linux_amd64, skipping verification` instead of `Checksum verification passed`.
- **After this fix**: all 14 tests in `tests/command.bats` pass.

Ran locally via `docker compose run --rm tests` (the `buildkite/plugin-tester` image). I also ran `shellcheck hooks/command` — clean, no new warnings.

Note: I didn't see `tests/command.bats` wired into `.buildkite/pipeline.yml` (the pipeline's `:golang: Test` step runs `go test ./...` only) — worth double-checking that the bats suite actually runs somewhere in CI, since it clearly wasn't catching this.

## Scope

Kept this surgical — did not touch the pre-existing, unrelated arch-mapping quirks I noticed while reading `get_architecture()` (e.g. `i386`/`i686` folding into `amd64` while `linux_386` ships as a separate asset; 32-bit `arm` variants folding into `arm64`; the checksum lookup being a substring `grep` rather than an exact line match). Happy to file those separately if useful, but they're independent of this case-sensitivity bug.