### PR TITLE
[SUP-5882]: Pin goreleaser docker image to v2.17.1

### DIFF
--- a/.buildkite/pipeline.release.yml
+++ b/.buildkite/pipeline.release.yml
@@ -62,7 +62,7 @@ steps:
           parameters:
             GITHUB_TOKEN: /pipelines/buildkite/monorail-plugin-monorepo-diff-release/github-token
       - docker#v5.14.0:
-          image: "goreleaser/goreleaser:v2"
+          image: "goreleaser/goreleaser:v2.17.1"
           always-pull: true
           workdir: /plugin
           environment:


### PR DESCRIPTION
## Context

Pins the goreleaser Docker image to `v2.17.1` in `pipeline.release.yml`. The previous tag `v2` does not exist on Docker Hub, causing the release step to fail when pulling the image.
