### PR TITLE
[SUP-7788]: chore: use GitHub release notes format for goreleaser changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,7 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 changelog:
+  use: github
   sort: asc
   filters:
     exclude:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ snapshot:
   version_template: "{{ incpatch .Version }}-next"
 
 changelog:
-  use: github
+  use: github-native
   sort: asc
   filters:
     exclude:


### PR DESCRIPTION
## Description

Updates `.goreleaser.yml` to use GitHub's release notes API (`use: github`) for the changelog. This restores the "What's Changed" format with PR links and contributors that was present in releases before the move to Buildkite (SUP-5882).